### PR TITLE
remove  values from source, add gh pages workflow to publish references

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,227 @@
+name: Deploy to GitHub Pages
+
+on:
+  workflow_run:
+    workflows: ["Release and Publish"]
+    types:
+      - completed
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get latest release
+        id: get_release
+        run: |
+          LATEST_RELEASE=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r '.tag_name')
+          echo "VERSION=$LATEST_RELEASE" >> $GITHUB_OUTPUT
+          echo "Latest release: $LATEST_RELEASE"
+
+      - name: Download release artifact
+        run: |
+          ASSET_URL=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r '.assets[] | select(.name | contains(".zip")) | .browser_download_url')
+          echo "Downloading from: $ASSET_URL"
+          curl -L -o schemata.zip "$ASSET_URL"
+          
+      - name: Extract and flatten structure
+        run: |
+          # Extract the release artifact
+          unzip schemata.zip -d temp_dist
+          
+          # Create the flattened structure for GitHub Pages
+          mkdir -p pages_dist/note/kind
+          mkdir -p pages_dist/message
+          mkdir -p pages_dist/tag
+          
+          # Process all NIPs to extract kinds and messages
+          if [ -d "temp_dist/nips" ]; then
+            for nip_dir in temp_dist/nips/*; do
+              if [ -d "$nip_dir" ]; then
+                nip_name=$(basename "$nip_dir")
+                
+                # Extract kind schemas (events)
+                for kind_dir in "$nip_dir"/kind-*; do
+                  if [ -d "$kind_dir" ]; then
+                    kind_num=$(basename "$kind_dir" | sed 's/kind-//')
+                    if [ -f "$kind_dir/schema.json" ]; then
+                      # Copy as {kind}.json to note/kind/
+                      cp "$kind_dir/schema.json" "pages_dist/note/kind/${kind_num}.json"
+                      echo "Copied kind $kind_num from $nip_name"
+                    fi
+                  fi
+                done
+                
+                # Extract tag schemas
+                if [ -d "$nip_dir/tag" ]; then
+                  for tag_dir in "$nip_dir/tag"/*; do
+                    if [ -d "$tag_dir" ]; then
+                      tag_name=$(basename "$tag_dir")
+                      if [ -f "$tag_dir/schema.json" ]; then
+                        # If tag already exists from another NIP, use nip prefix
+                        if [ -f "pages_dist/tag/${tag_name}.json" ]; then
+                          tag_filename="${nip_name}_${tag_name}"
+                        else
+                          tag_filename="${tag_name}"
+                        fi
+                        
+                        cp "$tag_dir/schema.json" "pages_dist/tag/${tag_filename}.json"
+                        echo "Copied tag $tag_name from $nip_name"
+                      fi
+                    fi
+                  done
+                fi
+                
+                # Extract message schemas (protocol messages)
+                if [ -d "$nip_dir/messages" ]; then
+                  for msg_dir in "$nip_dir/messages"/*; do
+                    if [ -d "$msg_dir" ]; then
+                      msg_type=$(basename "$msg_dir")
+                      if [ -f "$msg_dir/schema.json" ]; then
+                        # Convert message type to uppercase for consistency
+                        # e.g., client-req -> REQ, relay-event -> EVENT, etc.
+                        case "$msg_type" in
+                          client-req) msg_name="REQ" ;;
+                          client-event) msg_name="EVENT" ;;
+                          client-close) msg_name="CLOSE" ;;
+                          client-auth) msg_name="AUTH" ;;
+                          relay-event) msg_name="EVENT" ;;
+                          relay-ok) msg_name="OK" ;;
+                          relay-eose) msg_name="EOSE" ;;
+                          relay-closed) msg_name="CLOSED" ;;
+                          relay-notice) msg_name="NOTICE" ;;
+                          relay-auth) msg_name="AUTH" ;;
+                          *) msg_name=$(echo "$msg_type" | tr '[:lower:]' '[:upper:]' | tr '-' '_') ;;
+                        esac
+                        
+                        # If message already exists, use nip prefix
+                        if [ -f "pages_dist/message/${msg_name}.json" ]; then
+                          msg_name="${nip_name}_${msg_name}"
+                        fi
+                        
+                        cp "$msg_dir/schema.json" "pages_dist/message/${msg_name}.json"
+                        echo "Copied message $msg_name from $nip_name"
+                      fi
+                    fi
+                  done
+                fi
+              fi
+            done
+          fi
+          
+          # Create an index.html for basic navigation
+          cat > pages_dist/index.html << 'EOF'
+          <!DOCTYPE html>
+          <html lang="en">
+          <head>
+              <meta charset="UTF-8">
+              <meta name="viewport" content="width=device-width, initial-scale=1.0">
+              <title>Nostr Schemata</title>
+              <style>
+                  body {
+                      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+                      max-width: 800px;
+                      margin: 0 auto;
+                      padding: 2rem;
+                      line-height: 1.6;
+                  }
+                  h1 { color: #333; }
+                  h2 { color: #666; margin-top: 2rem; }
+                  ul { list-style-type: none; padding: 0; }
+                  li { margin: 0.5rem 0; }
+                  a {
+                      color: #0366d6;
+                      text-decoration: none;
+                      padding: 0.25rem 0.5rem;
+                      display: inline-block;
+                  }
+                  a:hover {
+                      text-decoration: underline;
+                  }
+                  .schema-type {
+                      background: #f6f8fa;
+                      border-radius: 4px;
+                      padding: 1rem;
+                      margin: 1rem 0;
+                  }
+                  code {
+                      background: #f3f4f6;
+                      padding: 0.2rem 0.4rem;
+                      border-radius: 3px;
+                      font-size: 0.9em;
+                  }
+              </style>
+          </head>
+          <body>
+              <h1>Nostr Schemata</h1>
+              <p>JSON Schema definitions for Nostr events. Access schemas directly by kind:</p>
+              
+              <div class="schema-type">
+                  <h2>Note Schemas</h2>
+                  <p>Access via: <code>/note/kind/{kind}.json</code></p>
+                  <p>Example: <a href="/note/kind/0.json">/note/kind/0.json</a> for profile metadata</p>
+                  <p>Example: <a href="/note/kind/1.json">/note/kind/1.json</a> for text note</p>
+              </div>
+              
+              <div class="schema-type">
+                  <h2>Tag Schemas</h2>
+                  <p>Access via: <code>/tag/{tag_name}.json</code></p>
+                  <p>Example: <a href="/tag/e.json">/tag/e.json</a> for event reference tags</p>
+                  <p>Example: <a href="/tag/p.json">/tag/p.json</a> for pubkey tags</p>
+                  <p>Example: <a href="/tag/a.json">/tag/a.json</a> for replaceable event tags</p>
+                  <p>Example: <a href="/tag/t.json">/tag/t.json</a> for hashtag tags</p>
+              </div>
+              
+              <div class="schema-type">
+                  <h2>Protocol Message Schemas</h2>
+                  <p>Access via: <code>/message/{message_type}.json</code></p>
+                  <p>Example: <a href="/message/REQ.json">/message/REQ.json</a> for request messages</p>
+                  <p>Example: <a href="/message/EVENT.json">/message/EVENT.json</a> for event messages</p>
+                  <p>Example: <a href="/message/OK.json">/message/OK.json</a> for acknowledgment messages</p>
+              </div>
+              
+              <div class="schema-type">
+                  <h2>Repository</h2>
+                  <p>View source and contribute at <a href="https://github.com/${{ github.repository }}">GitHub</a></p>
+              </div>
+          </body>
+          </html>
+          EOF
+          
+          # List what we've created for verification
+          echo "Created structure:"
+          ls -la pages_dist/
+          echo "Note schemas (by kind):"
+          ls -la pages_dist/note/kind/ | head -20
+          echo "Tag schemas:"
+          ls -la pages_dist/tag/ | head -20
+          echo "Protocol message schemas:"
+          ls -la pages_dist/message/ | head -20
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'pages_dist'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -6,6 +6,12 @@ on:
     types:
       - completed
   workflow_dispatch:
+    inputs:
+      deploy_reason:
+        description: 'Reason for manual deployment'
+        required: false
+        type: string
+        default: 'Manual deployment'
 
 permissions:
   contents: read

--- a/add-schema-ids.js
+++ b/add-schema-ids.js
@@ -1,0 +1,138 @@
+/**
+ * add-schema-ids.js
+ * 
+ * Adds $id property to all JSON schema files in dist/nips
+ * The $id will point to the GitHub Pages URL matching the flattened structure
+ */
+
+import {
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  existsSync
+} from 'fs';
+import { resolve, join, basename, dirname } from 'path';
+
+const GITHUB_PAGES_BASE = 'https://nostrability.github.io/schemata';
+const nipsDir = resolve('dist/nips');
+
+function getAllJsonFiles(dir) {
+  if (!existsSync(dir)) return [];
+  const entries = readdirSync(dir, { withFileTypes: true });
+  return entries.flatMap((ent) => {
+    const full = join(dir, ent.name);
+    if (ent.isDirectory()) {
+      return getAllJsonFiles(full);
+    }
+    if (ent.name.endsWith('.json')) {
+      return [full];
+    }
+    return [];
+  });
+}
+
+function getSchemaId(filePath) {
+  // Parse the path to determine the type and generate the correct URL
+  const relativePath = filePath.replace(nipsDir, '').replace(/^[\\/]/, '');
+  const parts = relativePath.split(/[/\\]/);
+  
+  // parts[0] = nip-XX
+  // parts[1] = kind-YY | messages | tag | ...
+  // parts[2] = schema.json or subfolder
+  
+  if (parts.length < 3) return null;
+  
+  const nipDir = parts[0]; // e.g., "nip-01"
+  const typeDir = parts[1]; // e.g., "kind-1", "messages", "tag"
+  
+  // Handle kind schemas
+  if (typeDir.startsWith('kind-')) {
+    const kind = typeDir.replace('kind-', '');
+    if (basename(filePath) === 'schema.json') {
+      return `${GITHUB_PAGES_BASE}/note/kind/${kind}.json`;
+    }
+  }
+  
+  // Handle message schemas
+  if (typeDir === 'messages' && parts.length >= 3) {
+    const messageType = parts[2]; // e.g., "client-req", "relay-event"
+    if (basename(filePath) === 'schema.json') {
+      // Convert message type to uppercase format used in GitHub Pages
+      let msgName;
+      switch(messageType) {
+        case 'client-req': msgName = 'REQ'; break;
+        case 'client-event': msgName = 'EVENT'; break;
+        case 'client-close': msgName = 'CLOSE'; break;
+        case 'client-auth': msgName = 'AUTH'; break;
+        case 'relay-event': msgName = 'EVENT'; break;
+        case 'relay-ok': msgName = 'OK'; break;
+        case 'relay-eose': msgName = 'EOSE'; break;
+        case 'relay-closed': msgName = 'CLOSED'; break;
+        case 'relay-notice': msgName = 'NOTICE'; break;
+        case 'relay-auth': msgName = 'AUTH'; break;
+        default: 
+          msgName = messageType.toUpperCase().replace(/-/g, '_');
+      }
+      
+      // Note: In the deploy workflow, if there are conflicts, it prefixes with nip name
+      // For now, we'll use the simple name as the primary ID
+      return `${GITHUB_PAGES_BASE}/message/${msgName}.json`;
+    }
+  }
+  
+  // Handle tag schemas
+  if (typeDir === 'tag') {
+    // If we only have nip-XX/tag/schema.json (generic tag schema)
+    if (parts.length === 2 && parts[1] === 'tag' && basename(filePath) === 'schema.json') {
+      return `${GITHUB_PAGES_BASE}/tag/generic.json`;
+    } 
+    // If we have nip-XX/tag/X/schema.json (specific tag schema)
+    else if (parts.length >= 3 && parts[2] !== 'schema.json') {
+      const tagName = parts[2]; // e.g., "e", "p", "a", "_P"
+      if (basename(filePath) === 'schema.json') {
+        return `${GITHUB_PAGES_BASE}/tag/${tagName}.json`;
+      }
+    }
+    // If parts[2] is 'schema.json', it means we have nip-XX/tag/schema.json
+    else if (parts.length === 3 && parts[2] === 'schema.json') {
+      return `${GITHUB_PAGES_BASE}/tag/generic.json`;
+    }
+  }
+  
+  // For other schemas that don't match the flattened structure, return null
+  return null;
+}
+
+function processSchema(filePath) {
+  try {
+    const content = readFileSync(filePath, 'utf8');
+    const schema = JSON.parse(content);
+    
+    const schemaId = getSchemaId(filePath);
+    if (schemaId) {
+      // Add or overwrite the $id property
+      schema['$id'] = schemaId;
+      
+      // Write back the modified schema
+      writeFileSync(filePath, JSON.stringify(schema, null, 2));
+      console.log(`Added $id to ${filePath}: ${schemaId}`);
+    } else {
+      console.log(`Skipping ${filePath} - doesn't match flattened structure`);
+    }
+  } catch (error) {
+    console.error(`Error processing ${filePath}:`, error.message);
+  }
+}
+
+function main() {
+  console.log('Adding $id properties to schema files...');
+  
+  const jsonFiles = getAllJsonFiles(nipsDir);
+  console.log(`Found ${jsonFiles.length} JSON files to process`);
+  
+  jsonFiles.forEach(processSchema);
+  
+  console.log('Finished adding $id properties!');
+}
+
+main();

--- a/nips/nip-01/kind-0/schema.content.yaml
+++ b/nips/nip-01/kind-0/schema.content.yaml
@@ -1,5 +1,4 @@
-$id: "https://schemata.nostr.watch/note/kind/0/content"
-$schema: "https://json-schema.org/draft/2020-12/schema"
+s$schema: "https://json-schema.org/draft/2020-12/schema"
 title: "Metadata Event Schema"
 type: "object"
 properties:

--- a/nips/nip-01/kind-0/schema.yaml
+++ b/nips/nip-01/kind-0/schema.yaml
@@ -1,4 +1,3 @@
-$id: "https://schemata.nostr.watch/note/kind/0"
 $schema: http://json-schema.org/draft-07/schema#
 title: kind0
 allOf: 

--- a/nips/nip-01/kind-1/schema.yaml
+++ b/nips/nip-01/kind-1/schema.yaml
@@ -1,4 +1,3 @@
-$id: "https://schemata.nostr.watch/note/kind/1"
 $schema: http://json-schema.org/draft-07/schema#
 title: kind1
 allOf: 

--- a/nips/nip-01/messages/client-close/schema.yaml
+++ b/nips/nip-01/messages/client-close/schema.yaml
@@ -1,4 +1,3 @@
-$id: 'https://schemata.nostr.watch/message/client/close'
 type: "array"
 items: 
 - const: "CLOSE"

--- a/nips/nip-01/messages/client-event/schema.yaml
+++ b/nips/nip-01/messages/client-event/schema.yaml
@@ -1,4 +1,3 @@
-$id: 'https://schemata.nostr.watch/message/client/event'
 type: "array"
 title: "Client Event Message"
 description: "A message for publishing a NIP-01 note to a relay"

--- a/nips/nip-01/messages/client-req/schema.yaml
+++ b/nips/nip-01/messages/client-req/schema.yaml
@@ -1,4 +1,3 @@
-$id: 'https://schemata.nostr.watch/message/client/req'
 type: "array"
 items: 
 - const: "REQ"

--- a/nips/nip-01/messages/filter/schema.yaml
+++ b/nips/nip-01/messages/filter/schema.yaml
@@ -1,4 +1,3 @@
-$id: 'https://schemata.nostr.watch/message/filter'
 $schema: "http://json-schema.org/draft-07/schema#"
 type: "object"
 properties: 

--- a/nips/nip-01/messages/relay-closed/schema.yaml
+++ b/nips/nip-01/messages/relay-closed/schema.yaml
@@ -1,4 +1,3 @@
-$id: 'https://schemata.nostr.watch/message/relay/closed'
 type: "array"
 items: 
 - const: "CLOSED"

--- a/nips/nip-01/messages/relay-eose/schema.yaml
+++ b/nips/nip-01/messages/relay-eose/schema.yaml
@@ -1,4 +1,3 @@
-$id: 'https://schemata.nostr.watch/message/relay/eose'
 type: "array"
 description: "End Of Subscription Event"
 items: 

--- a/nips/nip-01/messages/relay-event/schema.yaml
+++ b/nips/nip-01/messages/relay-event/schema.yaml
@@ -1,4 +1,3 @@
-$id: 'https://schemata.nostr.watch/message/relay/event'
 type: "array"
 description: "A message sent by relays to clients in response to a client request."
 items: 

--- a/nips/nip-01/messages/relay-notice/schema.yaml
+++ b/nips/nip-01/messages/relay-notice/schema.yaml
@@ -1,4 +1,3 @@
-$id: 'https://schemata.nostr.watch/message/relay/notice'
 type: "array"
 description: "A message sent by relays to clients in response to a client request, usually to inform them of an issue."
 items: 

--- a/nips/nip-01/messages/relay-ok/schema.yaml
+++ b/nips/nip-01/messages/relay-ok/schema.yaml
@@ -1,4 +1,3 @@
-$id: 'https://schemata.nostr.watch/message/relay-ok'
 type: "array"
 items: 
 - const: "OK"

--- a/nips/nip-01/note-unsigned/schema.yaml
+++ b/nips/nip-01/note-unsigned/schema.yaml
@@ -1,4 +1,3 @@
-$id: "https://schemata.nostr.watch/note"
 $schema: http://json-schema.org/draft-07/schema
 type: object
 properties:

--- a/nips/nip-01/note/schema.yaml
+++ b/nips/nip-01/note/schema.yaml
@@ -1,4 +1,3 @@
-$id: "https://schemata.nostr.watch/note"
 $schema: http://json-schema.org/draft-07/schema
 type: object
 properties:

--- a/nips/nip-01/tag/a/schema.yaml
+++ b/nips/nip-01/tag/a/schema.yaml
@@ -1,4 +1,3 @@
-$id: 'https://schemata.nostr.watch/note/tag/a'
 $schema: "http://json-schema.org/draft-07/schema#"
 allOf:
   - $ref: "@/tag.yaml"

--- a/nips/nip-01/tag/d/schema.yaml
+++ b/nips/nip-01/tag/d/schema.yaml
@@ -1,4 +1,3 @@
-$id: "https://schemata.nostr.watch/note/tag/d"
 $schema: "http://json-schema.org/draft-07/schema#"
 allOf:
   - $ref: "@/tag.yaml"

--- a/nips/nip-01/tag/e/schema.yaml
+++ b/nips/nip-01/tag/e/schema.yaml
@@ -1,4 +1,3 @@
-$id: 'https://schemata.nostr.watch/note/tag/e'
 $schema: "http://json-schema.org/draft-07/schema#"
 allOf:
   - $ref: "@/tag.yaml"

--- a/nips/nip-01/tag/p/schema.yaml
+++ b/nips/nip-01/tag/p/schema.yaml
@@ -1,4 +1,3 @@
-$id: 'https://schemata.nostr.watch/note/tag/p'
 $schema: "http://json-schema.org/draft-07/schema#"
 allOf:
   - $ref: "@/tag.yaml"

--- a/nips/nip-01/tag/schema.yaml
+++ b/nips/nip-01/tag/schema.yaml
@@ -1,4 +1,3 @@
-$id: 'https://schemata.nostr.watch/tag'
 $schema: "http://json-schema.org/draft-07/schema#"
 type: array
 items:

--- a/nips/nip-01/tag/t/schema.yaml
+++ b/nips/nip-01/tag/t/schema.yaml
@@ -1,4 +1,3 @@
-$id: "https://schemata.nostr.watch/note/tag/t"
 $schema: "http://json-schema.org/draft-07/schema#"
 allOf:
   - $ref: "@/tag.yaml"

--- a/nips/nip-02/kind-3/schema.content.yaml
+++ b/nips/nip-02/kind-3/schema.content.yaml
@@ -1,4 +1,3 @@
-$id: 'https://schemata.nostr.watch/note/kind/3/content'
 $schema: http://json-schema.org/draft-07/schema#
 title: kind3Content
 type: object

--- a/nips/nip-02/kind-3/schema.yaml
+++ b/nips/nip-02/kind-3/schema.yaml
@@ -1,4 +1,3 @@
-$id: 'https://schemata.nostr.watch/note/kind/3'
 $schema: http://json-schema.org/draft-07/schema#
 title: kind3
 allOf: 

--- a/nips/nip-11/schema.yaml
+++ b/nips/nip-11/schema.yaml
@@ -1,4 +1,4 @@
-"$id": https://schemata.nostr.watch/document/info
+"$id": https://nostrability.github.io/schemata/document/info
 "$schema": http://json-schema.org/draft-07/schema#
 title: NIP-11
 type: object

--- a/nips/nip-18/tag/k/schema.yaml
+++ b/nips/nip-18/tag/k/schema.yaml
@@ -1,4 +1,3 @@
-$id: 'https://schemata.nostr.watch/note/tag/k'
 $schema: "http://json-schema.org/draft-07/schema#"
 allOf:
   - $ref: "@/tag.yaml"

--- a/nips/nip-22/kind-1111/schema.yaml
+++ b/nips/nip-22/kind-1111/schema.yaml
@@ -1,4 +1,3 @@
-$id: "https://schemata.nostr.watch/note/kind/1111"
 $schema: http://json-schema.org/draft-07/schema#
 title: kind1111
 allOf: 

--- a/nips/nip-22/tag/_A/schema.yaml
+++ b/nips/nip-22/tag/_A/schema.yaml
@@ -1,4 +1,3 @@
-$id: 'https://schemata.nostr.watch/note/tag/A'
 $schema: "http://json-schema.org/draft-07/schema#"
 allOf: 
   - $ref: "@/tag/a.yaml"

--- a/nips/nip-22/tag/_E/schema.yaml
+++ b/nips/nip-22/tag/_E/schema.yaml
@@ -1,4 +1,3 @@
-$id: 'https://schemata.nostr.watch/note/tag/E'
 $schema: "http://json-schema.org/draft-07/schema#"
 allOf: 
   - $ref: "@/tag/e.yaml"

--- a/nips/nip-22/tag/_K/schema.yaml
+++ b/nips/nip-22/tag/_K/schema.yaml
@@ -1,4 +1,3 @@
-$id: 'https://schemata.nostr.watch/note/tag/K'
 $schema: "http://json-schema.org/draft-07/schema#"
 allOf: 
   - $ref: "@/tag/k.yaml"

--- a/nips/nip-22/tag/_P/schema.yaml
+++ b/nips/nip-22/tag/_P/schema.yaml
@@ -1,4 +1,3 @@
-$id: 'https://schemata.nostr.watch/note/tag/P'
 $schema: "http://json-schema.org/draft-07/schema#"
 allOf: 
   - $ref: "@/tag/p.yaml"

--- a/nips/nip-40/messages/client-auth/schema.yaml
+++ b/nips/nip-40/messages/client-auth/schema.yaml
@@ -1,4 +1,3 @@
-$id: 'https://schemata.nostr.watch/message/client/auth'
 type: "array"
 items: 
 - const: "AUTH"

--- a/nips/nip-40/messages/relay-auth/schema.yaml
+++ b/nips/nip-40/messages/relay-auth/schema.yaml
@@ -1,4 +1,3 @@
-$id: 'https://schemata.nostr.watch/message/relay/auth'
 type: "array"
 items: 
 - const: "AUTH"

--- a/nips/nip-65/kind-10002/schema.yaml
+++ b/nips/nip-65/kind-10002/schema.yaml
@@ -1,4 +1,3 @@
-$id: 'https://schemata.nostr.watch/note/kind/3'
 $schema: http://json-schema.org/draft-07/schema#
 title: kind10002
 allOf: 

--- a/nips/nip-65/tag/r/schema.yaml
+++ b/nips/nip-65/tag/r/schema.yaml
@@ -1,4 +1,3 @@
-$id: "https://schemata.nostr.watch/note/tag/d"
 $schema: "http://json-schema.org/draft-07/schema#"
 allOf:
   - $ref: "@/tag.yaml"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "clean": "rm -rf dist && mkdir -p dist",
-    "build": "pnpm clean && make && node ./build.js",
+    "build": "pnpm clean && make && node ./add-schema-ids.js && node ./build.js",
     "build:all": "pnpm build && pnpm packages",
     "build:test": "pnpm build && pnpm test",
     "convert": "pnpm convert:note && pnpm convert:content",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@apidevtools/json-schema-ref-parser':
         specifier: ^11.7.2
         version: 11.7.3
-      '@nostrwatch/schemata':
-        specifier: workspace:^
-        version: 'link:'
       ajv:
         specifier: 8.17.1
         version: 8.17.1


### PR DESCRIPTION
add github pages deployment for remote references to nostrability github pages.

instructions:

  1. GitHub Pages Source

  Go to Settings → Pages → Build and deployment:
  - Source: Select "GitHub Actions" (not "Deploy from a branch")
  - This allows the workflow to deploy using the actions/deploy-pages action

  2. Workflow Permissions

  Go to Settings → Actions → General → Workflow permissions:
  - Enable "Read and write permissions"
  - OR keep "Read repository contents and packages permissions" since the workflow already has:
  permissions:
    contents: read
    pages: write
    id-token: write

  3. GitHub Pages Environment (automatically created)

  The workflow uses environment: github-pages which will be created automatically on first deployment.

  4. Repository Visibility

  - Public repos: GitHub Pages works by default
  - Private repos: Requires GitHub Pro/Team/Enterprise

  Once configured, you can:
  1. Manually trigger the workflow from Actions tab → Deploy to GitHub Pages → Run workflow
  2. Or wait for the next release to trigger it automatically

  The GitHub Pages URL will be: https://nostrability.github.io/schemata/