### PR TITLE
docs(AGENTS): clarify testing policy (use vitest; no standalone test.js)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,7 @@ schemata/
 - Keep `master` as the main branch
 - Use semantic versioning for releases
 - Utilize vitest framework
-- Make sure the schemas test the data structure contained in payloads
+- Make sure schemas test the data structure contained in payloads
 - Ensure that schemas provided programmatic results, such that the result can be used in the release workflow to block releases when a test is failing, or block a PR merge when a test is failing.
 
 ## Schema Validation Properties

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,7 @@ schemata/
 - Use absolute paths in `$ref` (use `@/` aliases or relative paths)
 - Create documentation without being asked
 - Commit changes without explicit user request
+- Create standalone test.js files
 
 ### DO:
 - Follow existing schema patterns and conventions
@@ -143,6 +144,9 @@ schemata/
 - Test schemas with valid/invalid examples
 - Keep `master` as the main branch
 - Use semantic versioning for releases
+- Utilize vitest framework
+- Make sure the schemas test the data structure contained in payloads
+- Ensure that schemas provided programmatic results, such that the result can be used in the release workflow to block releases when a test is failing, or block a PR merge when a test is failing.
 
 ## Schema Validation Properties
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,7 +146,7 @@ schemata/
 - Use semantic versioning for releases
 - Utilize vitest framework
 - Make sure schemas test the data structure contained in payloads
-- Ensure that schemas provided programmatic results, such that the result can be used in the release workflow to block releases when a test is failing, or block a PR merge when a test is failing.
+- Ensure that schemas provide programmatic results, such that the result can be used in the release workflow to block releases when a test is failing, or block a PR merge when a test is failing.
 
 ## Schema Validation Properties
 


### PR DESCRIPTION
docs(AGENTS): clarify testing policy and CI gating

This PR updates AGENTS.md to align with current testing expectations:

- Add to DO NOT:
  - Do not create standalone `test.js` files
- Add to DO:
  - Utilize vitest framework for tests
  - Ensure schemas test the actual data structures in payloads (events, messages, tags)
  - Ensure tests produce programmatic results that can block releases/PR merges on failure (CI gating)

Rationale:
- Consolidate testing under vitest so contributors follow the same tooling
- Avoid ad-hoc scripts that bypass CI
- Make test outcomes first-class signals in CI/CD (release and PR checks)
