### PR TITLE
feat(nip-56): add kind-1984 report event + tags

### DIFF
--- a/nips/nip-56/kind-1984/schema.yaml
+++ b/nips/nip-56/kind-1984/schema.yaml
@@ -15,6 +15,6 @@ allOf:
           # MUST include at least one report tag (p/e/x) with a report type as the 3rd item
           - contains:
               anyOf:
-                - $ref: "nips/nip-56/tag/p/schema.yaml"
-                - $ref: "nips/nip-56/tag/e/schema.yaml"
-                - $ref: "nips/nip-56/tag/x/schema.yaml"
+                - $ref: "@/nips/nip-56/tag/p/schema.yaml"
+                - $ref: "@/nips/nip-56/tag/e/schema.yaml"
+                - $ref: "@/nips/nip-56/tag/x/schema.yaml"

--- a/nips/nip-56/kind-1984/schema.yaml
+++ b/nips/nip-56/kind-1984/schema.yaml
@@ -11,10 +11,10 @@ allOf:
         allOf:
           # MUST include a p tag referencing the reported user's pubkey
           - contains:
-              $ref: "@/tag/p.yaml"
+              $ref: "nips/nip-56/tag/p/schema.yaml"
           # MUST include at least one report tag (p/e/x) with a report type as the 3rd item
           - contains:
               anyOf:
-                - $ref: "@/nips/nip-56/tag/p/schema.yaml"
-                - $ref: "@/nips/nip-56/tag/e/schema.yaml"
-                - $ref: "@/nips/nip-56/tag/x/schema.yaml"
+                - $ref: "nips/nip-56/tag/p/schema.yaml"
+                - $ref: "nips/nip-56/tag/e/schema.yaml"
+                - $ref: "nips/nip-56/tag/x/schema.yaml"


### PR DESCRIPTION
Adds NIP-56 Report (kind 1984) schema.

Summary
- kind-1984 extends base note schema; enforces kind: 1984
- tags must include a p tag (reported pubkey)
- report tag must be present among p/e/x with a report type (nudity | malware | profanity | illegal | spam | impersonation | other)
- optional server tag for blob locations (https? URL)

Files
- nips/nip-56/kind-1984/schema.yaml
- nips/nip-56/tag/{p,e,x,server}/schema.yaml
- nips/nip-56/kind-1984/samples/{valid.json,invalid-*.json}

Validation
- Built locally; samples included for CI.
- Example event provided by user validates.

Notes
- $id is added during build as per repo process.
- One pre-existing nip-02 sample test is failing on master; not modified here.
