### PR TITLE
NIP-32 labeling (kind 1985, L/l tags) + NIP-36 content-warning

### DIFF
--- a/@/tag/_L.yaml
+++ b/@/tag/_L.yaml
@@ -1,0 +1,3 @@
+allOf:
+  - $ref: "nips/nip-32/tag/L/schema.yaml"
+

--- a/@/tag/content-warning.yaml
+++ b/@/tag/content-warning.yaml
@@ -1,0 +1,3 @@
+allOf:
+  - $ref: "nips/nip-36/tag/content-warning/schema.yaml"
+

--- a/@/tag/l.yaml
+++ b/@/tag/l.yaml
@@ -1,0 +1,3 @@
+allOf:
+  - $ref: "nips/nip-32/tag/l/schema.yaml"
+

--- a/nips/nip-32/kind-1985/schema.yaml
+++ b/nips/nip-32/kind-1985/schema.yaml
@@ -1,0 +1,22 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+title: kind1985
+description: "Labeling event as defined by NIP-32"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 1985
+      tags:
+        type: array
+        description: "Must include at least one label ('l') and one target tag (e, p, a, r, or t)."
+        allOf:
+          - contains:
+              $ref: "@/tag/l.yaml"
+          - contains:
+              anyOf:
+                - $ref: "@/tag/e.yaml"
+                - $ref: "@/tag/p.yaml"
+                - $ref: "@/tag/a.yaml"
+                - $ref: "@/tag/r.yaml"
+                - $ref: "@/tag/t.yaml"

--- a/nips/nip-32/tag/L/schema.yaml
+++ b/nips/nip-32/tag/L/schema.yaml
@@ -1,0 +1,13 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    description: "Label namespace tag (NIP-32). Second element is namespace or '#<target-tag>' marker."
+    minItems: 2
+    items:
+      - const: "L"
+      - type: string
+        title: "namespace"
+        description: "A namespace identifier; may start with '#' to indicate label applies to the value of the target tag."
+    additionalItems: true
+

--- a/nips/nip-32/tag/L/schema.yaml
+++ b/nips/nip-32/tag/L/schema.yaml
@@ -9,5 +9,5 @@ allOf:
       - type: string
         title: "namespace"
         description: "A namespace identifier; may start with '#' to indicate label applies to the value of the target tag."
-    additionalItems: true
+    additionalItems: false
 

--- a/nips/nip-32/tag/l/schema.yaml
+++ b/nips/nip-32/tag/l/schema.yaml
@@ -1,0 +1,16 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    description: "Label tag (NIP-32). Second element is label value; optional third element 'mark' matches an 'L' tag in the same event."
+    minItems: 2
+    items:
+      - const: "l"
+      - type: string
+        title: "label"
+        description: "A short, meaningful label string."
+      - type: string
+        title: "mark"
+        description: "Optional namespace mark; SHOULD match an 'L' tag value in the same event if present."
+    additionalItems: false
+

--- a/nips/nip-36/tag/content-warning/schema.yaml
+++ b/nips/nip-36/tag/content-warning/schema.yaml
@@ -1,0 +1,13 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    description: "Content warning tag (NIP-36). Optional reason as second element."
+    minItems: 1
+    items:
+      - const: "content-warning"
+      - type: string
+        title: "reason"
+        description: "Optional human-readable reason for the content warning"
+    additionalItems: false
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       ajv-cli:
         specifier: ^5.0.0
         version: 5.0.0(ts-node@10.9.2(@types/node@16.18.123)(typescript@4.9.5))
+      ajv-formats:
+        specifier: ^2.1.1
+        version: 2.1.1(ajv@8.17.1)
       esbuild:
         specifier: ^0.24.2
         version: 0.24.2


### PR DESCRIPTION
Summary
- Add NIP-32 labeling support:
  - New event kind 1985 schema requiring at least one label and one target tag.
  - New tag schemas for L (namespace) and l (label), with aliases.
- Add NIP-36 content-warning tag schema and alias.
- Fix NIP-01 e-tag schema (const should be "e", not "p").
- Ensure alias dereferences are always fresh by cleaning dist before builds.

Changes
- NIP-32
  - Add `nips/nip-32/kind-1985/schema.yaml` (extends `@/note.yaml`, `kind: 1985`).
  - Add `nips/nip-32/tag/L/schema.yaml` and alias `@/tag/_L.yaml`.
  - Add `nips/nip-32/tag/l/schema.yaml` and alias `@/tag/l.yaml`.
  - Kind 1985 `tags` requires:
    - contains one `l` tag (`@/tag/l.yaml`)
    - contains at least one target tag: `e|p|a|r|t` via `@/tag/{e,p,a,r,t}.yaml`
- NIP-36
  - Add `nips/nip-36/tag/content-warning/schema.yaml` and alias `@/tag/content-warning.yaml`.
  - Tag shape: ["content-warning", reason?] with no extra items.
- NIP-01 fix
  - `nips/nip-01/tag/e/schema.yaml`: correct tuple first item to `const: "e"`.
- Build hygiene
  - `package.json`: prepend `make clean` to `pnpm build` to avoid stale alias deref outputs.

Rationale
- NIP-32/NIP-36 support brings labeling and content warning workflows into the schema set.
- Cleaning `dist/` prevents alias outputs (e.g., `@/tag/e.json`) from going stale after source changes.

Validation
- Built locally with `pnpm build`.
- Validated a sample NIP-32 kind-1985 event with Ajv against `dist/nips/nip-32/kind-1985/schema.json`: passes.
- Verified `dist/@/tag/e.json` dereferences with `const: "e"` after the fix.

Impact
- Non-breaking for existing consumers.
- `pnpm build` now re-generates from a clean `dist/`, which improves correctness at small cost to build time.

Follow-ups (optional)
- NIP-01 note schemas:
  - Consider tightening `tags.items` to `items: { $ref: "@/tag.yaml" }` (instead of a tuple list).
  - Add `sig` hex pattern validation.
- `nips/nip-01/messages/filter/schema.yaml` has stringified numbers/booleans (e.g., `minimum: "0"`) — consider normalizing types.

Checklist
- [x] New schemas follow directory and alias conventions.
- [x] No `$id` in sources; IDs added at build.
- [x] Build passes locally.
- [x] Kind and tag constraints match NIP-32/NIP-36 specs.
