### PR TITLE
feat(nip-10): e/q tags schemas, event shape enforcement, and tests

### DIFF
--- a/nips/nip-01/kind-0/schema.yaml
+++ b/nips/nip-01/kind-0/schema.yaml
@@ -2,3 +2,7 @@ $schema: http://json-schema.org/draft-07/schema#
 title: kind0
 allOf: 
   - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 0

--- a/nips/nip-01/kind-0/schema.yaml
+++ b/nips/nip-01/kind-0/schema.yaml
@@ -2,7 +2,6 @@ $schema: http://json-schema.org/draft-07/schema#
 title: kind0
 allOf: 
   - $ref: "@/note.yaml"
-  - type: object
-    properties:
+  - properties:
       kind:
         const: 0

--- a/nips/nip-01/kind-1/schema.yaml
+++ b/nips/nip-01/kind-1/schema.yaml
@@ -2,6 +2,3 @@ $schema: http://json-schema.org/draft-07/schema#
 title: kind1
 allOf: 
   - $ref: "@/note.yaml"
-  - properties:
-      kind:
-        const: 1

--- a/nips/nip-01/kind-1/schema.yaml
+++ b/nips/nip-01/kind-1/schema.yaml
@@ -2,3 +2,7 @@ $schema: http://json-schema.org/draft-07/schema#
 title: kind1
 allOf: 
   - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 1

--- a/nips/nip-01/kind-1/schema.yaml
+++ b/nips/nip-01/kind-1/schema.yaml
@@ -2,7 +2,6 @@ $schema: http://json-schema.org/draft-07/schema#
 title: kind1
 allOf: 
   - $ref: "@/note.yaml"
-  - type: object
-    properties:
+  - properties:
       kind:
         const: 1

--- a/nips/nip-01/messages/filter/schema.yaml
+++ b/nips/nip-01/messages/filter/schema.yaml
@@ -17,19 +17,19 @@ properties:
     type: "array"
     items: 
       type: "integer"
-      minimum: "0"
+      minimum: 0
     description: "A list of kind numbers"
   since: 
     type: "integer"
-    minimum: "0"
+    minimum: 0
     description: "An integer Unix timestamp in seconds, where events must have created_at >= since"
   until: 
     type: "integer"
-    minimum: "0"
+    minimum: 0
     description: "An integer Unix timestamp in seconds, where events must have created_at <= until"
   limit: 
     type: "integer"
-    minimum: "1"
+    minimum: 1
     description: "The maximum number of events relays SHOULD return in the initial query"
 patternProperties: 
   ^#[a-zA-Z]$: 
@@ -37,4 +37,4 @@ patternProperties:
     items: 
       type: "string"
     description: "A list of tag values, where specific tags (#e, #p) have designated meanings"
-additionalProperties: "false"
+additionalProperties: false

--- a/nips/nip-01/note-unsigned/schema.yaml
+++ b/nips/nip-01/note-unsigned/schema.yaml
@@ -21,7 +21,8 @@ properties:
     errorMessage: "tags must be an array of valid tag tuples"
     description: "The tags of the note"
     items:
-      $ref: "@/tag.yaml"
+      allOf:
+        - $ref: "@/tag.yaml"
       
 required:
 - content

--- a/nips/nip-01/note-unsigned/schema.yaml
+++ b/nips/nip-01/note-unsigned/schema.yaml
@@ -18,13 +18,14 @@ properties:
     description: "The public key of the note's author"
   tags:
     type: array
-    errorMessage: "tags must be an array of strings"
+    errorMessage: "tags must be an array of valid tag tuples"
     description: "The tags of the note"
     items:
-    - $ref: "@/tag.yaml"
+      $ref: "@/tag.yaml"
       
 required:
 - content
 - created_at
 - kind
 - tags
+additionalProperties: false

--- a/nips/nip-01/note-unsigned/schema.yaml
+++ b/nips/nip-01/note-unsigned/schema.yaml
@@ -21,8 +21,7 @@ properties:
     errorMessage: "tags must be an array of valid tag tuples"
     description: "The tags of the note"
     items:
-      allOf:
-        - $ref: "@/tag.yaml"
+      $ref: "@/tag.yaml"
       
 required:
 - content

--- a/nips/nip-01/note/schema.yaml
+++ b/nips/nip-01/note/schema.yaml
@@ -23,14 +23,15 @@ properties:
     description: "The public key of the note's author"
   sig:
     type: string
+    pattern: "^[a-f0-9]{128}$"
     errorMessage: "sig must be a string"
-    description: "The cryprographic signature of the note"
+    description: "The cryptographic signature of the note"
   tags:
     type: array
-    errorMessage: "tags must be an array of strings"
+    errorMessage: "tags must be an array of valid tag tuples"
     description: "The tags of the note"
     items:
-    - $ref: "@/tag.yaml"
+      $ref: "@/tag.yaml"
       
 required:
 - content
@@ -40,3 +41,4 @@ required:
 - pubkey
 - sig
 - tags
+additionalProperties: false

--- a/nips/nip-01/note/schema.yaml
+++ b/nips/nip-01/note/schema.yaml
@@ -30,8 +30,7 @@ properties:
     type: array
     errorMessage: "tags must be an array of valid tag tuples"
     description: "The tags of the note"
-    items:
-      $ref: "@/tag.yaml"
+    items: { $ref: "@/tag.yaml" }
       
 required:
 - content

--- a/nips/nip-01/note/schema.yaml
+++ b/nips/nip-01/note/schema.yaml
@@ -24,7 +24,7 @@ properties:
   sig:
     type: string
     pattern: "^[a-f0-9]{128}$"
-    errorMessage: "sig must be a string"
+    errorMessage: "sig must be 128 lowercase hex characters (64 bytes)"
     description: "The cryptographic signature of the note"
   tags:
     type: array

--- a/nips/nip-01/tag/e/samples/invalid.bad-const.json
+++ b/nips/nip-01/tag/e/samples/invalid.bad-const.json
@@ -1,0 +1,5 @@
+[
+  "p",
+  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "wss://relay.example.com"
+]

--- a/nips/nip-01/tag/e/samples/invalid.bad-id.json
+++ b/nips/nip-01/tag/e/samples/invalid.bad-id.json
@@ -1,0 +1,5 @@
+[
+  "e",
+  "zzzz",
+  "wss://relay.example.com"
+]

--- a/nips/nip-01/tag/e/samples/invalid.bad-marker.json
+++ b/nips/nip-01/tag/e/samples/invalid.bad-marker.json
@@ -1,0 +1,6 @@
+[
+  "e",
+  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "wss://relay.example.com",
+  "not-a-marker"
+]

--- a/nips/nip-01/tag/e/samples/invalid.bad-relay.json
+++ b/nips/nip-01/tag/e/samples/invalid.bad-relay.json
@@ -1,0 +1,5 @@
+[
+  "e",
+  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "http://not-allowed.example.com"
+]

--- a/nips/nip-01/tag/e/samples/valid.json
+++ b/nips/nip-01/tag/e/samples/valid.json
@@ -1,0 +1,7 @@
+[
+  "e",
+  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "wss://relay.example.com",
+  "reply",
+  "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+]

--- a/nips/nip-01/tag/e/schema.yaml
+++ b/nips/nip-01/tag/e/schema.yaml
@@ -1,11 +1,32 @@
 $schema: "http://json-schema.org/draft-07/schema#"
 allOf:
   - $ref: "@/tag.yaml"
+oneOf:
+  # Marked e-tag (preferred in NIP-10): ["e", <event-id>, <relay-url-or-empty>, <marker>, <pubkey>?]
+  - type: array
+    minItems: 4
+    maxItems: 5
+    items:
+      - const: "e"
+      - type: string
+        pattern: '^[a-f0-9]{64}$'
+      - anyOf:
+          - type: string
+            pattern: '^(ws://|wss://).+$'
+          - type: string
+            const: ""
+      - type: string
+        enum: ["reply", "root"]
+      - $ref: "@/secp256k1.yaml"
+    additionalItems: false
+  # Deprecated positional e-tag: ["e", <event-id>, <relay-url>?]
   - type: array
     minItems: 2
+    maxItems: 3
     items:
-      - const: "p"
-      - $ref: "@/secp256k1.yaml"
+      - const: "e"
+      - type: string
+        pattern: '^[a-f0-9]{64}$'
       - type: string
         pattern: '^(ws://|wss://).+$'
-    additionalItems: true
+    additionalItems: false

--- a/nips/nip-01/tag/e/schema.yaml
+++ b/nips/nip-01/tag/e/schema.yaml
@@ -16,7 +16,7 @@ oneOf:
           - type: string
             const: ""
       - type: string
-        enum: ["reply", "root", "mention"]
+        enum: ["reply", "root"]
       - $ref: "@/secp256k1.yaml"
     additionalItems: false
   # Deprecated positional e-tag: ["e", <event-id>, <relay-url>?]

--- a/nips/nip-01/tag/e/schema.yaml
+++ b/nips/nip-01/tag/e/schema.yaml
@@ -16,7 +16,7 @@ oneOf:
           - type: string
             const: ""
       - type: string
-        enum: ["reply", "root"]
+        enum: ["reply", "root", "mention"]
       - $ref: "@/secp256k1.yaml"
     additionalItems: false
   # Deprecated positional e-tag: ["e", <event-id>, <relay-url>?]

--- a/nips/nip-01/tag/e/schema.yaml
+++ b/nips/nip-01/tag/e/schema.yaml
@@ -7,7 +7,7 @@ oneOf:
     minItems: 4
     maxItems: 5
     items:
-      - const: "e"
+      - const: "e"  # tag identifier
       - type: string
         pattern: '^[a-f0-9]{64}$'
       - anyOf:
@@ -24,7 +24,7 @@ oneOf:
     minItems: 2
     maxItems: 3
     items:
-      - const: "e"
+      - const: "e"  # tag identifier
       - type: string
         pattern: '^[a-f0-9]{64}$'
       - type: string

--- a/nips/nip-18/tag/q/samples/invalid.bad-id.json
+++ b/nips/nip-18/tag/q/samples/invalid.bad-id.json
@@ -1,0 +1,5 @@
+[
+  "q",
+  "not-a-hex-id",
+  "wss://relay.example.com"
+]

--- a/nips/nip-18/tag/q/samples/invalid.bad-pubkey.json
+++ b/nips/nip-18/tag/q/samples/invalid.bad-pubkey.json
@@ -1,0 +1,6 @@
+[
+  "q",
+  "1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:foo",
+  "wss://relay.example.com",
+  "not-a-hex"
+]

--- a/nips/nip-18/tag/q/samples/invalid.bad-relay.json
+++ b/nips/nip-18/tag/q/samples/invalid.bad-relay.json
@@ -1,0 +1,5 @@
+[
+  "q",
+  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "http://not-allowed.example.com"
+]

--- a/nips/nip-18/tag/q/samples/valid.json
+++ b/nips/nip-18/tag/q/samples/valid.json
@@ -1,0 +1,6 @@
+[
+  "q",
+  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "wss://relay.example.com",
+  "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+]

--- a/nips/nip-18/tag/q/schema.yaml
+++ b/nips/nip-18/tag/q/schema.yaml
@@ -16,7 +16,7 @@ allOf:
           - type: string
             description: event address (kind:pubkey:identifier)
             pattern: '^\d+:[a-f0-9]{64}:.+$'
-      - anyOf:
+      - oneOf:
           - type: string
             pattern: '^(ws://|wss://).+$'
           - type: string

--- a/nips/nip-18/tag/q/schema.yaml
+++ b/nips/nip-18/tag/q/schema.yaml
@@ -35,8 +35,10 @@ allOf:
                 pattern: '^\d+:[a-f0-9]{64}:.+$'
           - oneOf:
               - type: string
+                description: relay URL (ws or wss)
                 pattern: '^(ws://|wss://).+$'
               - type: string
-                const: ""
+                description: empty placeholder when relay is omitted
+                enum: [""]
         additionalItems:
           $ref: "@/secp256k1.yaml"

--- a/nips/nip-18/tag/q/schema.yaml
+++ b/nips/nip-18/tag/q/schema.yaml
@@ -3,42 +3,21 @@ allOf:
   - $ref: "@/tag.yaml"
   - description: |
       Quote tag for quote-reposts (NIP-18). Mirrors NIP-10 e-tag tuple without the mark argument.
-      Structure: ["q", <event-id>, <relay-url>?, <pubkey>?]
-    oneOf:
-      # No relay provided; optional pubkey in position 3.
-      - type: array
-        minItems: 2
-        maxItems: 3
-        items:
-          - const: "q"
-          - anyOf:
-              - type: string
-                description: event id (32-byte hex)
-                pattern: '^[a-f0-9]{64}$'
-              - type: string
-                description: event address (kind:pubkey:identifier)
-                pattern: '^\d+:[a-f0-9]{64}:.+$'
-        additionalItems:
-          $ref: "@/secp256k1.yaml"
-      # Relay supplied (or explicitly empty); optional pubkey in position 4.
-      - type: array
-        minItems: 3
-        maxItems: 4
-        items:
-          - const: "q"
-          - anyOf:
-              - type: string
-                description: event id (32-byte hex)
-                pattern: '^[a-f0-9]{64}$'
-              - type: string
-                description: event address (kind:pubkey:identifier)
-                pattern: '^\d+:[a-f0-9]{64}:.+$'
-          - oneOf:
-              - type: string
-                description: relay URL (ws or wss)
-                pattern: '^(ws://|wss://).+$'
-              - type: string
-                description: empty placeholder when relay is omitted
-                enum: [""]
-        additionalItems:
-          $ref: "@/secp256k1.yaml"
+      Structure: ["q", <event-id or event address>, <relay-url>, <pubkey>?]
+    type: array
+    minItems: 3
+    maxItems: 4
+    items:
+      - const: "q"
+      - anyOf:
+          - type: string
+            description: event id (32-byte hex)
+            pattern: '^[a-f0-9]{64}$'
+          - type: string
+            description: event address (kind:pubkey:identifier)
+            pattern: '^\d+:[a-f0-9]{64}:.+$'
+      - type: string
+        description: relay URL (ws or wss)
+        pattern: '^(ws://|wss://).+$'
+      - $ref: "@/secp256k1.yaml"
+    additionalItems: false

--- a/nips/nip-18/tag/q/schema.yaml
+++ b/nips/nip-18/tag/q/schema.yaml
@@ -9,10 +9,17 @@ allOf:
     maxItems: 4
     items:
       - const: "q"
-      - type: string
-        pattern: '^[a-f0-9]{64}$'
-      - type: string
-        pattern: '^(ws://|wss://).+$'
+      - anyOf:
+          - type: string
+            description: event id (32-byte hex)
+            pattern: '^[a-f0-9]{64}$'
+          - type: string
+            description: event address (kind:pubkey:identifier)
+            pattern: '^\d+:[a-f0-9]{64}:.+$'
+      - anyOf:
+          - type: string
+            pattern: '^(ws://|wss://).+$'
+          - type: string
+            const: ""
       - $ref: "@/secp256k1.yaml"
     additionalItems: false
-

--- a/nips/nip-18/tag/q/schema.yaml
+++ b/nips/nip-18/tag/q/schema.yaml
@@ -1,25 +1,42 @@
 $schema: "http://json-schema.org/draft-07/schema#"
 allOf:
   - $ref: "@/tag.yaml"
-  - type: array
-    description: |
+  - description: |
       Quote tag for quote-reposts (NIP-18). Mirrors NIP-10 e-tag tuple without the mark argument.
       Structure: ["q", <event-id>, <relay-url>?, <pubkey>?]
-    minItems: 2
-    maxItems: 4
-    items:
-      - const: "q"
-      - anyOf:
-          - type: string
-            description: event id (32-byte hex)
-            pattern: '^[a-f0-9]{64}$'
-          - type: string
-            description: event address (kind:pubkey:identifier)
-            pattern: '^\d+:[a-f0-9]{64}:.+$'
-      - oneOf:
-          - type: string
-            pattern: '^(ws://|wss://).+$'
-          - type: string
-            const: ""
-      - $ref: "@/secp256k1.yaml"
-    additionalItems: false
+    oneOf:
+      # No relay provided; optional pubkey in position 3.
+      - type: array
+        minItems: 2
+        maxItems: 3
+        items:
+          - const: "q"
+          - anyOf:
+              - type: string
+                description: event id (32-byte hex)
+                pattern: '^[a-f0-9]{64}$'
+              - type: string
+                description: event address (kind:pubkey:identifier)
+                pattern: '^\d+:[a-f0-9]{64}:.+$'
+        additionalItems:
+          $ref: "@/secp256k1.yaml"
+      # Relay supplied (or explicitly empty); optional pubkey in position 4.
+      - type: array
+        minItems: 3
+        maxItems: 4
+        items:
+          - const: "q"
+          - anyOf:
+              - type: string
+                description: event id (32-byte hex)
+                pattern: '^[a-f0-9]{64}$'
+              - type: string
+                description: event address (kind:pubkey:identifier)
+                pattern: '^\d+:[a-f0-9]{64}:.+$'
+          - oneOf:
+              - type: string
+                pattern: '^(ws://|wss://).+$'
+              - type: string
+                const: ""
+        additionalItems:
+          $ref: "@/secp256k1.yaml"

--- a/nips/nip-56/kind-1984/samples/valid.json
+++ b/nips/nip-56/kind-1984/samples/valid.json
@@ -9,6 +9,6 @@
     ["l", "NS-nud", "social.nos.ontology"]
   ],
   "content": "",
-  "sig": "deadbeef"
+  "sig": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
 }
 


### PR DESCRIPTION
This PR updates schemas per NIP-10 and tightens validation.

Changes
- NIP-10 e-tags
  - Marked: ["e", <id>, <relay| "">, <"reply"|"root">, <pubkey>?]
  - Positional (deprecated): ["e", <id>, <relay>?]
- NIP-18 q-tags
  - ["q", <64hex | kind:pubkey:identifier>, <relay| "">?, <pubkey>]
- Event shape and kinds
  - additionalProperties: false in notes
  - sig pattern: ^[a-f0-9]{128}$
  - tags.items: $ref "@/tag.yaml"
  - kind-0=0, kind-1=1
- Messages filter
  - numeric minimums as numbers; additionalProperties: false
- Typo fix: cryptographic
- Samples: valid/invalid for e/q

Notes
- No changes related to NIP-56 are included in this PR.

Build/Tests
- pnpm build passes locally
- Samples run via scripts/samples.spec.js (pnpm build:test)
