### PR TITLE
Add NIP-38 user status schema and supporting tags

### DIFF
--- a/@/tag/expiration.yaml
+++ b/@/tag/expiration.yaml
@@ -1,0 +1,2 @@
+allOf: 
+  - $ref: "nips/nip-38/tag/expiration/schema.yaml"

--- a/@/tag/status-type.yaml
+++ b/@/tag/status-type.yaml
@@ -1,0 +1,2 @@
+allOf: 
+  - $ref: "nips/nip-38/tag/status-type/schema.yaml"

--- a/nips/nip-01/kind-0/schema.content.yaml
+++ b/nips/nip-01/kind-0/schema.content.yaml
@@ -1,4 +1,4 @@
-$schema: "https://json-schema.org/draft/2020-12/schema"
+$schema: "http://json-schema.org/draft-07/schema#"
 title: "Metadata Event Schema"
 type: "object"
 properties:

--- a/nips/nip-01/kind-0/schema.content.yaml
+++ b/nips/nip-01/kind-0/schema.content.yaml
@@ -1,4 +1,4 @@
-s$schema: "https://json-schema.org/draft/2020-12/schema"
+$schema: "https://json-schema.org/draft/2020-12/schema"
 title: "Metadata Event Schema"
 type: "object"
 properties:

--- a/nips/nip-38/kind-30315/schema.yaml
+++ b/nips/nip-38/kind-30315/schema.yaml
@@ -19,14 +19,8 @@ allOf:
         allOf:
           - not:
               contains:
-                type: array
-                minItems: 2
-                items:
-                  - const: "expiration"
-                  - type: string
-                    not:
-                      pattern: '^[0-9]+$'
-                additionalItems: true
+                $ref: "@/tag/expiration.yaml"
+                not: true
     required:
       - kind
       - tags

--- a/nips/nip-38/kind-30315/schema.yaml
+++ b/nips/nip-38/kind-30315/schema.yaml
@@ -1,0 +1,32 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind30315
+description: User Status event (addressable, NIP-38)
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 30315
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        contains:
+          $ref: "@/tag/status-type.yaml"
+        errorMessage:
+          contains: "tags must include a d tag identifying the user status type"
+        allOf:
+          - not:
+              contains:
+                type: array
+                minItems: 2
+                items:
+                  - const: "expiration"
+                  - type: string
+                    not:
+                      pattern: '^[0-9]+$'
+                additionalItems: true
+    required:
+      - kind
+      - tags

--- a/nips/nip-38/tag/expiration/schema.yaml
+++ b/nips/nip-38/tag/expiration/schema.yaml
@@ -1,0 +1,11 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "expiration"
+      - type: string
+        pattern: '^[0-9]+$'
+    additionalItems: false

--- a/nips/nip-38/tag/status-type/schema.yaml
+++ b/nips/nip-38/tag/status-type/schema.yaml
@@ -1,0 +1,10 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    items:
+      - const: "d"
+      - type: string
+        minLength: 1
+    additionalItems: true


### PR DESCRIPTION
## Summary
     - Introduced `nips/nip-38/kind-30315/schema.yaml` extending the base note
  schema for User Status events, enforcing `kind:30315`, requiring a status-
  identifying d tag, and validating any expiration tag is numeric.
     - Added reusable aliases `@/tag/status-type.yaml` and `@/tag/
  expiration.yaml` that reference the new tag schemas under `nips/nip-38/
  tag/`.
     - Fixed the `` typo in `nips/nip-01/kind-0/schema.content.yaml`.

     ## Testing
     - pnpm build