### PR TITLE
Add NIP-17 schemas

### DIFF
--- a/@/note-unsigned.yaml
+++ b/@/note-unsigned.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-01/note-unsigned/schema.yaml"

--- a/@/tag/blurhash.yaml
+++ b/@/tag/blurhash.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-17/tag/blurhash/schema.yaml"

--- a/@/tag/decryption-key.yaml
+++ b/@/tag/decryption-key.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-17/tag/decryption-key/schema.yaml"

--- a/@/tag/decryption-nonce.yaml
+++ b/@/tag/decryption-nonce.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-17/tag/decryption-nonce/schema.yaml"

--- a/@/tag/dim.yaml
+++ b/@/tag/dim.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-17/tag/dim/schema.yaml"

--- a/@/tag/dm-relay.yaml
+++ b/@/tag/dm-relay.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-17/tag/relay/schema.yaml"

--- a/@/tag/encryption-algorithm.yaml
+++ b/@/tag/encryption-algorithm.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-17/tag/encryption-algorithm/schema.yaml"

--- a/@/tag/fallback.yaml
+++ b/@/tag/fallback.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-17/tag/fallback/schema.yaml"

--- a/@/tag/file-type.yaml
+++ b/@/tag/file-type.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-17/tag/file-type/schema.yaml"

--- a/@/tag/ox.yaml
+++ b/@/tag/ox.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-17/tag/ox/schema.yaml"

--- a/@/tag/size.yaml
+++ b/@/tag/size.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-17/tag/size/schema.yaml"

--- a/@/tag/subject.yaml
+++ b/@/tag/subject.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-17/tag/subject/schema.yaml"

--- a/@/tag/thumb.yaml
+++ b/@/tag/thumb.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-17/tag/thumb/schema.yaml"

--- a/@/tag/x.yaml
+++ b/@/tag/x.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-17/tag/x/schema.yaml"

--- a/nips/nip-17/kind-10050/schema.yaml
+++ b/nips/nip-17/kind-10050/schema.yaml
@@ -15,11 +15,13 @@ allOf:
         type: array
         items:
           $ref: "@/tag.yaml"
-        minItems: 1
         allOf:
-          - contains:
-              $ref: "@/tag/relay.yaml"
-            errorMessage:
-              contains: "tags must include at least one relay tag"
+          - if:
+              minItems: 1
+            then:
+              contains:
+                $ref: "@/tag/dm-relay.yaml"
+              errorMessage:
+                contains: "tags must include at least one relay tag when relays are configured"
     required:
       - kind

--- a/nips/nip-17/kind-10050/schema.yaml
+++ b/nips/nip-17/kind-10050/schema.yaml
@@ -1,0 +1,25 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind10050
+description: Preferred DM relay list event defined by NIP-17
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 10050
+        description: "Kind 10050 enumerates preferred relays for receiving direct messages"
+      content:
+        type: string
+        description: "Optional human readable notes; usually an empty string"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/relay.yaml"
+            errorMessage:
+              contains: "tags must include at least one relay tag"
+    required:
+      - kind

--- a/nips/nip-17/kind-14/schema.yaml
+++ b/nips/nip-17/kind-14/schema.yaml
@@ -1,0 +1,38 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind14
+description: Private direct message event defined by NIP-17
+allOf:
+  - $ref: "@/note-unsigned.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 14
+        description: "Kind 14 identifies an unsigned private direct message"
+      id:
+        allOf:
+          - $ref: "@/secp256k1.yaml"
+        description: "Deterministic event hash as defined in NIP-01"
+      pubkey:
+        allOf:
+          - $ref: "@/secp256k1.yaml"
+        description: "Sender public key"
+      content:
+        type: string
+        description: "Plain text chat message content"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/p.yaml"
+        errorMessage:
+          contains: "tags must include at least one p tag identifying a receiver"
+    required:
+      - kind
+      - id
+      - pubkey
+  - not:
+      required:
+        - sig

--- a/nips/nip-17/kind-15/schema.yaml
+++ b/nips/nip-17/kind-15/schema.yaml
@@ -1,0 +1,59 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind15
+description: Encrypted file message event defined by NIP-17
+allOf:
+  - $ref: "@/note-unsigned.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 15
+        description: "Kind 15 identifies an unsigned encrypted file message"
+      id:
+        allOf:
+          - $ref: "@/secp256k1.yaml"
+        description: "Deterministic event hash as defined in NIP-01"
+      pubkey:
+        allOf:
+          - $ref: "@/secp256k1.yaml"
+        description: "Sender public key"
+      content:
+        type: string
+        format: uri
+        description: "URL pointing to the encrypted file payload"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 6
+        allOf:
+          - contains:
+              $ref: "@/tag/p.yaml"
+            errorMessage:
+              contains: "tags must include at least one p tag identifying a receiver"
+          - contains:
+              $ref: "@/tag/file-type.yaml"
+            errorMessage:
+              contains: "tags must include a file-type tag specifying the original MIME type"
+          - contains:
+              $ref: "@/tag/encryption-algorithm.yaml"
+            errorMessage:
+              contains: "tags must include an encryption-algorithm tag"
+          - contains:
+              $ref: "@/tag/decryption-key.yaml"
+            errorMessage:
+              contains: "tags must include a decryption-key tag"
+          - contains:
+              $ref: "@/tag/decryption-nonce.yaml"
+            errorMessage:
+              contains: "tags must include a decryption-nonce tag"
+          - contains:
+              $ref: "@/tag/x.yaml"
+            errorMessage:
+              contains: "tags must include an x tag with the encrypted file checksum"
+    required:
+      - kind
+      - id
+      - pubkey
+  - not:
+      required:
+        - sig

--- a/nips/nip-17/tag/blurhash/schema.yaml
+++ b/nips/nip-17/tag/blurhash/schema.yaml
@@ -1,0 +1,11 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    description: "Blurhash placeholder for the encrypted media"
+    minItems: 2
+    items:
+      - const: "blurhash"
+      - type: string
+        minLength: 6
+    additionalItems: false

--- a/nips/nip-17/tag/decryption-key/schema.yaml
+++ b/nips/nip-17/tag/decryption-key/schema.yaml
@@ -1,0 +1,11 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    description: "Key required to decrypt the encrypted file"
+    minItems: 2
+    items:
+      - const: "decryption-key"
+      - type: string
+        minLength: 1
+    additionalItems: false

--- a/nips/nip-17/tag/decryption-nonce/schema.yaml
+++ b/nips/nip-17/tag/decryption-nonce/schema.yaml
@@ -1,0 +1,11 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    description: "Nonce required alongside the decryption key"
+    minItems: 2
+    items:
+      - const: "decryption-nonce"
+      - type: string
+        minLength: 1
+    additionalItems: false

--- a/nips/nip-17/tag/dim/schema.yaml
+++ b/nips/nip-17/tag/dim/schema.yaml
@@ -1,0 +1,11 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    description: "Image dimensions in the form <width>x<height>"
+    minItems: 2
+    items:
+      - const: "dim"
+      - type: string
+        pattern: '^\d+x\d+$'
+    additionalItems: false

--- a/nips/nip-17/tag/encryption-algorithm/schema.yaml
+++ b/nips/nip-17/tag/encryption-algorithm/schema.yaml
@@ -1,0 +1,12 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    description: "Encryption algorithm used for the attached file"
+    minItems: 2
+    items:
+      - const: "encryption-algorithm"
+      - type: string
+        enum:
+          - "aes-gcm"
+    additionalItems: false

--- a/nips/nip-17/tag/fallback/schema.yaml
+++ b/nips/nip-17/tag/fallback/schema.yaml
@@ -1,0 +1,13 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    description: "Fallback locations for retrieving the encrypted file"
+    minItems: 2
+    items:
+      - const: "fallback"
+      - type: string
+        format: uri
+    additionalItems:
+      type: string
+      format: uri

--- a/nips/nip-17/tag/file-type/schema.yaml
+++ b/nips/nip-17/tag/file-type/schema.yaml
@@ -1,0 +1,11 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    description: "MIME type of the original file before encryption"
+    minItems: 2
+    items:
+      - const: "file-type"
+      - type: string
+        pattern: '^[\w!#$&^_.+-]+/[\w!#$&^_.+-]+$'
+    additionalItems: false

--- a/nips/nip-17/tag/file-type/schema.yaml
+++ b/nips/nip-17/tag/file-type/schema.yaml
@@ -7,5 +7,5 @@ allOf:
     items:
       - const: "file-type"
       - type: string
-        pattern: '^[\w!#$&^_.+-]+/[\w!#$&^_.+-]+$'
+        pattern: '^[a-zA-Z][a-zA-Z0-9!#$&^_-]*/[a-zA-Z0-9*][a-zA-Z0-9!#$&^_.+-]*(\s*;\s*[a-zA-Z0-9!#$&^_.+-]+=[a-zA-Z0-9!#$&^_.+-]+)*$'
     additionalItems: false

--- a/nips/nip-17/tag/ox/schema.yaml
+++ b/nips/nip-17/tag/ox/schema.yaml
@@ -1,0 +1,11 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    description: "Checksum of the original file prior to encryption"
+    minItems: 2
+    items:
+      - const: "ox"
+      - type: string
+        pattern: '^[a-f0-9]{64}$'
+    additionalItems: false

--- a/nips/nip-17/tag/relay/schema.yaml
+++ b/nips/nip-17/tag/relay/schema.yaml
@@ -7,5 +7,5 @@ allOf:
     items:
       - const: "relay"
       - type: string
-        pattern: '^(ws://|wss://).+$'
+        pattern: '^wss?://[a-zA-Z0-9.-]+(?::[0-9]+)?(?:/.*)?$'
     additionalItems: false

--- a/nips/nip-17/tag/relay/schema.yaml
+++ b/nips/nip-17/tag/relay/schema.yaml
@@ -1,0 +1,11 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    description: "Preferred relay endpoint for receiving direct messages"
+    minItems: 2
+    items:
+      - const: "relay"
+      - type: string
+        pattern: '^(ws://|wss://).+$'
+    additionalItems: false

--- a/nips/nip-17/tag/size/schema.yaml
+++ b/nips/nip-17/tag/size/schema.yaml
@@ -1,0 +1,11 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    description: "Size of the encrypted file in bytes"
+    minItems: 2
+    items:
+      - const: "size"
+      - type: string
+        pattern: '^[0-9]+$'
+    additionalItems: false

--- a/nips/nip-17/tag/subject/schema.yaml
+++ b/nips/nip-17/tag/subject/schema.yaml
@@ -1,0 +1,11 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    description: "Conversation subject for a private room"
+    minItems: 2
+    items:
+      - const: "subject"
+      - type: string
+        minLength: 1
+    additionalItems: false

--- a/nips/nip-17/tag/thumb/schema.yaml
+++ b/nips/nip-17/tag/thumb/schema.yaml
@@ -1,0 +1,11 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    description: "Thumbnail URL for the encrypted media"
+    minItems: 2
+    items:
+      - const: "thumb"
+      - type: string
+        format: uri
+    additionalItems: false

--- a/nips/nip-17/tag/x/schema.yaml
+++ b/nips/nip-17/tag/x/schema.yaml
@@ -1,0 +1,11 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    description: "Checksum of the encrypted file"
+    minItems: 2
+    items:
+      - const: "x"
+      - type: string
+        pattern: '^[a-f0-9]{64}$'
+    additionalItems: false


### PR DESCRIPTION
## Summary
- add unsigned note alias to reuse NIP-01 structure without signatures
- add NIP-17 event schemas for kinds 14, 15, and 10050
- add NIP-17 tag schemas plus aliases for DM metadata

## Testing
- pnpm build