### PR TITLE
Add NIP-88 poll schemas

### DIFF
--- a/@/tag/endsAt.yaml
+++ b/@/tag/endsAt.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-88/tag/endsAt/schema.yaml"

--- a/@/tag/option.yaml
+++ b/@/tag/option.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-88/tag/option/schema.yaml"

--- a/@/tag/polltype.yaml
+++ b/@/tag/polltype.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-88/tag/polltype/schema.yaml"

--- a/@/tag/relay.yaml
+++ b/@/tag/relay.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-88/tag/relay/schema.yaml"

--- a/@/tag/response.yaml
+++ b/@/tag/response.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-88/tag/response/schema.yaml"

--- a/nips/nip-88/kind-1018/schema.yaml
+++ b/nips/nip-88/kind-1018/schema.yaml
@@ -1,0 +1,35 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+title: kind1018
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 1018
+        errorMessage: "kind must be 1018 for poll responses"
+      tags:
+        type: array
+        contains:
+          $ref: "@/tag/response.yaml"
+        allOf:
+          - contains:
+              $ref: "@/tag/e.yaml"
+            errorMessage:
+              contains: "response events must reference a poll event via an e tag"
+        items:
+          allOf:
+            - if:
+                items:
+                  - const: "response"
+              then:
+                $ref: "@/tag/response.yaml"
+            - if:
+                items:
+                  - const: "e"
+              then:
+                $ref: "@/tag/e.yaml"
+        errorMessage:
+          contains: "response events must include at least one response tag"
+    required:
+      - kind
+      - tags

--- a/nips/nip-88/kind-1068/schema.yaml
+++ b/nips/nip-88/kind-1068/schema.yaml
@@ -1,0 +1,45 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+title: kind1068
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 1068
+        errorMessage: "kind must be 1068 for poll events"
+      tags:
+        type: array
+        contains:
+          $ref: "@/tag/option.yaml"
+        allOf:
+          - contains:
+              $ref: "@/tag/relay.yaml"
+            errorMessage:
+              contains: "poll events must include at least one relay tag"
+        items:
+          allOf:
+            - if:
+                items:
+                  - const: "option"
+              then:
+                $ref: "@/tag/option.yaml"
+            - if:
+                items:
+                  - const: "relay"
+              then:
+                $ref: "@/tag/relay.yaml"
+            - if:
+                items:
+                  - const: "polltype"
+              then:
+                $ref: "@/tag/polltype.yaml"
+            - if:
+                items:
+                  - const: "endsAt"
+              then:
+                $ref: "@/tag/endsAt.yaml"
+        errorMessage:
+          contains: "poll events must include at least one option tag"
+    required:
+      - kind
+      - tags

--- a/nips/nip-88/tag/endsAt/schema.yaml
+++ b/nips/nip-88/tag/endsAt/schema.yaml
@@ -1,0 +1,12 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    items:
+      - const: "endsAt"
+      - type: string
+        pattern: '^[0-9]+$'
+    additionalItems: true
+    errorMessage:
+      items: "endsAt tag must start with 'endsAt' followed by a unix timestamp in seconds"

--- a/nips/nip-88/tag/option/schema.yaml
+++ b/nips/nip-88/tag/option/schema.yaml
@@ -1,0 +1,15 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 3
+    items:
+      - const: "option"
+      - type: string
+        pattern: '^[A-Za-z0-9]+$'
+      - type: string
+        minLength: 1
+    additionalItems: true
+    errorMessage:
+      minItems: "option tag must provide an identifier and label"
+      items: "option tag must start with 'option', followed by an alphanumeric id and a non-empty label"

--- a/nips/nip-88/tag/polltype/schema.yaml
+++ b/nips/nip-88/tag/polltype/schema.yaml
@@ -1,0 +1,14 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    items:
+      - const: "polltype"
+      - type: string
+        enum:
+          - singlechoice
+          - multiplechoice
+    additionalItems: false
+    errorMessage:
+      items: "polltype tag must be ['polltype', 'singlechoice'|'multiplechoice']"

--- a/nips/nip-88/tag/relay/schema.yaml
+++ b/nips/nip-88/tag/relay/schema.yaml
@@ -1,0 +1,12 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    items:
+      - const: "relay"
+      - type: string
+        pattern: '^(ws://|wss://).+$'
+    additionalItems: true
+    errorMessage:
+      items: "relay tag must start with 'relay' followed by a valid ws or wss URL"

--- a/nips/nip-88/tag/response/schema.yaml
+++ b/nips/nip-88/tag/response/schema.yaml
@@ -1,0 +1,12 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    items:
+      - const: "response"
+      - type: string
+        pattern: '^[A-Za-z0-9]+$'
+    additionalItems: true
+    errorMessage:
+      items: "response tag must be ['response', '<alphanumeric option id>']"


### PR DESCRIPTION
## Summary
- add schemas for NIP-88 poll (kind 1068) and response (kind 1018) events
- introduce reusable option, relay, polltype, endsAt, and response tag definitions
- wire the new tag aliases under @/tag for downstream references

## Testing
- not run (no automated checks available)