### PR TITLE
Add MLS (NIP-EE) event and tag schemas

### DIFF
--- a/@/tag/ciphersuite.yaml
+++ b/@/tag/ciphersuite.yaml
@@ -1,0 +1,2 @@
+allOf: 
+  - $ref: "nips/nip-ee/tag/ciphersuite/schema.yaml"

--- a/@/tag/client.yaml
+++ b/@/tag/client.yaml
@@ -1,0 +1,2 @@
+allOf: 
+  - $ref: "nips/nip-ee/tag/client/schema.yaml"

--- a/@/tag/extensions.yaml
+++ b/@/tag/extensions.yaml
@@ -1,0 +1,2 @@
+allOf: 
+  - $ref: "nips/nip-ee/tag/extensions/schema.yaml"

--- a/@/tag/h.yaml
+++ b/@/tag/h.yaml
@@ -1,0 +1,2 @@
+allOf: 
+  - $ref: "nips/nip-ee/tag/h/schema.yaml"

--- a/@/tag/mls_protocol_version.yaml
+++ b/@/tag/mls_protocol_version.yaml
@@ -1,0 +1,2 @@
+allOf: 
+  - $ref: "nips/nip-ee/tag/mls_protocol_version/schema.yaml"

--- a/@/tag/relay.yaml
+++ b/@/tag/relay.yaml
@@ -1,0 +1,2 @@
+allOf: 
+  - $ref: "nips/nip-ee/tag/relay/schema.yaml"

--- a/nips/nip-ee/kind-10051/schema.yaml
+++ b/nips/nip-ee/kind-10051/schema.yaml
@@ -1,0 +1,24 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind10051
+description: KeyPackage Relay List Event (NIP-EE)
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 10051
+      content:
+        type: string
+        errorMessage: "content must be a string (typically empty)"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        contains:
+          $ref: "@/tag/relay.yaml"
+        errorMessage:
+          contains: "tags must include at least one relay tag listing a KeyPackage relay"
+    required:
+      - kind
+      - tags

--- a/nips/nip-ee/kind-443/schema.yaml
+++ b/nips/nip-ee/kind-443/schema.yaml
@@ -1,0 +1,31 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind443
+description: MLS KeyPackage Event (NIP-EE)
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 443
+      content:
+        type: string
+        pattern: '^(?:[0-9A-Fa-f]{2})+$'
+        errorMessage: "content must be a hex-encoded MLS KeyPackageBundle"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/mls_protocol_version.yaml"
+          - contains:
+              $ref: "@/tag/ciphersuite.yaml"
+          - contains:
+              $ref: "@/tag/extensions.yaml"
+        errorMessage:
+          contains: "tags must include mls_protocol_version, ciphersuite, and extensions tags"
+    required:
+      - kind
+      - content
+      - tags

--- a/nips/nip-ee/kind-444/schema.yaml
+++ b/nips/nip-ee/kind-444/schema.yaml
@@ -1,0 +1,32 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind444
+description: MLS Welcome Event (NIP-EE)
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 444
+      sig:
+        const: ""
+      content:
+        type: string
+        minLength: 1
+        errorMessage: "content must contain the serialized MLS Welcome message"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 2
+        allOf:
+          - contains:
+              $ref: "@/tag/e.yaml"
+          - contains:
+              $ref: "@/tag/relays.yaml"
+        errorMessage:
+          contains: "tags must include e (KeyPackage reference) and relays tags"
+    required:
+      - kind
+      - sig
+      - content
+      - tags

--- a/nips/nip-ee/kind-445/schema.yaml
+++ b/nips/nip-ee/kind-445/schema.yaml
@@ -1,0 +1,26 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind445
+description: MLS Group Message Event (NIP-EE)
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 445
+      content:
+        type: string
+        minLength: 1
+        errorMessage: "content must contain the NIP-44 encrypted MLSMessage"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        contains:
+          $ref: "@/tag/h.yaml"
+        errorMessage:
+          contains: "tags must include an h tag with the MLS group identifier"
+    required:
+      - kind
+      - content
+      - tags

--- a/nips/nip-ee/tag/ciphersuite/schema.yaml
+++ b/nips/nip-ee/tag/ciphersuite/schema.yaml
@@ -1,0 +1,13 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "ciphersuite"
+      - type: string
+        pattern: '^0x[0-9A-Fa-f]{4}$'
+    errorMessage:
+      pattern: "ciphersuite tag value must be a 4-digit hex identifier like 0x0001"
+    additionalItems: false

--- a/nips/nip-ee/tag/client/schema.yaml
+++ b/nips/nip-ee/tag/client/schema.yaml
@@ -5,11 +5,19 @@ allOf:
     minItems: 2
     maxItems: 4
     items:
+      # Tag name, must be "client"
       - const: "client"
+        errorMessage: "First item must be the string 'client'."
+      # Client name (arbitrary string, min 1 character)
       - type: string
         minLength: 1
+        errorMessage: "Second item must be a non-empty client name."
+      # Identifier (64-character lowercase hex string)
       - type: string
         pattern: '^[a-f0-9]{64}$'
+        errorMessage: "Third item must be a 64-character lowercase hexadecimal identifier."
+      # Relay URL (must start with ws:// or wss://)
       - type: string
         pattern: '^(ws://|wss://).+$'
+        errorMessage: "Fourth item must be a relay URL starting with ws:// or wss://."
     additionalItems: false

--- a/nips/nip-ee/tag/client/schema.yaml
+++ b/nips/nip-ee/tag/client/schema.yaml
@@ -14,7 +14,7 @@ allOf:
         errorMessage: "Second item must be a non-empty client name."
       # Identifier (64-character lowercase hex string)
       - type: string
-        pattern: '^[a-f0-9]{64}$'
+        pattern: '^[0-9A-Fa-f]{64}$'
         errorMessage: "Third item must be a 64-character lowercase hexadecimal identifier."
       # Relay URL (must start with ws:// or wss://)
       - type: string

--- a/nips/nip-ee/tag/client/schema.yaml
+++ b/nips/nip-ee/tag/client/schema.yaml
@@ -1,0 +1,15 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 4
+    items:
+      - const: "client"
+      - type: string
+        minLength: 1
+      - type: string
+        pattern: '^[a-f0-9]{64}$'
+      - type: string
+        pattern: '^(ws://|wss://).+$'
+    additionalItems: false

--- a/nips/nip-ee/tag/extensions/schema.yaml
+++ b/nips/nip-ee/tag/extensions/schema.yaml
@@ -1,0 +1,12 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    items:
+      - const: "extensions"
+    additionalItems:
+      type: string
+      pattern: '^0x[0-9A-Fa-f]{4}$'
+    errorMessage:
+      additionalItems: "extensions tag values must be 4-digit hex identifiers like 0x0001"

--- a/nips/nip-ee/tag/h/schema.yaml
+++ b/nips/nip-ee/tag/h/schema.yaml
@@ -1,0 +1,13 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "h"
+      - type: string
+        pattern: '^[0-9A-Fa-f]{64}$'
+    additionalItems: false
+    errorMessage:
+      pattern: "h tag value must be a 32-byte hex-encoded identifier"

--- a/nips/nip-ee/tag/mls_protocol_version/schema.yaml
+++ b/nips/nip-ee/tag/mls_protocol_version/schema.yaml
@@ -1,0 +1,13 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "mls_protocol_version"
+      - type: string
+        pattern: '^[0-9]+(\.[0-9]+){1,2}$'
+    errorMessage:
+      pattern: "mls_protocol_version tag value must be a semantic version like '1.0'"
+    additionalItems: false

--- a/nips/nip-ee/tag/relay/schema.yaml
+++ b/nips/nip-ee/tag/relay/schema.yaml
@@ -1,0 +1,12 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    items:
+      - const: "relay"
+      - type: string
+        pattern: '^(ws://|wss://).+$'
+    additionalItems: true
+    errorMessage:
+      pattern: "relay tag value must be a valid ws:// or wss:// URL"


### PR DESCRIPTION
## Summary
- add MLS-focused tag aliases for protocol version, ciphersuite, extensions, client metadata, relay targets, and group identifiers
- add schemas for kinds 443, 444, 445, and 10051 aligned with NIP-EE requirements
- wire new tags into alias layer for reuse across future schemas

## Testing
- pnpm build