### PR TITLE
Add NIP-04 encrypted direct message schema

### DIFF
--- a/nips/nip-04/kind-4/samples/invalid.missing-p-tag.json
+++ b/nips/nip-04/kind-4/samples/invalid.missing-p-tag.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 4,
+  "tags": [
+    ["e", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"]
+  ],
+  "content": "Zm9vYmFy?iv=YWJjMTIz",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-04/kind-4/samples/invalid.wrong-content-format.json
+++ b/nips/nip-04/kind-4/samples/invalid.wrong-content-format.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 4,
+  "tags": [
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"]
+  ],
+  "content": "this-is-not-encrypted",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-04/kind-4/samples/valid.json
+++ b/nips/nip-04/kind-4/samples/valid.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 4,
+  "tags": [
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["e", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"]
+  ],
+  "content": "Zm9vYmFy?iv=YWJjMTIz",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-04/kind-4/schema.yaml
+++ b/nips/nip-04/kind-4/schema.yaml
@@ -1,0 +1,41 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind4
+description: Encrypted Direct Message (NIP-04)
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 4
+      content:
+        type: string
+        pattern: "^[A-Za-z0-9+/]+={0,2}\\?iv=[A-Za-z0-9+/]+={0,2}$"
+        errorMessage: "content must be '<ciphertext>?iv=<initialization_vector>' where both values are base64"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/p.yaml"
+          - anyOf:
+              - not:
+                  contains:
+                    type: array
+                    minItems: 1
+                    items:
+                      - const: "e"
+              - contains:
+                  type: array
+                  minItems: 2
+                  items:
+                    - const: "e"
+                    - type: string
+                      pattern: "^[a-f0-9]{64}$"
+        errorMessage:
+          contains: "tags must include a p tag identifying the intended recipient"
+    required:
+      - kind
+      - content
+      - tags

--- a/nips/nip-04/kind-4/schema.yaml
+++ b/nips/nip-04/kind-4/schema.yaml
@@ -19,20 +19,19 @@ allOf:
         allOf:
           - contains:
               $ref: "@/tag/p.yaml"
-          - anyOf:
-              - not:
-                  contains:
-                    type: array
-                    minItems: 1
-                    items:
-                      - const: "e"
-              - contains:
-                  type: array
-                  minItems: 2
-                  items:
-                    - const: "e"
-                    - type: string
-                      pattern: "^[a-f0-9]{64}$"
+          - not:
+              contains:
+                type: array
+                minItems: 1
+                items:
+                  - const: "e"
+          - contains:
+              type: array
+              minItems: 2
+              items:
+                - const: "e"
+                - type: string
+                  pattern: "^[a-f0-9]{64}$"
         errorMessage:
           contains: "tags must include a p tag identifying the intended recipient"
     required:

--- a/nips/nip-04/kind-4/schema.yaml
+++ b/nips/nip-04/kind-4/schema.yaml
@@ -19,19 +19,20 @@ allOf:
         allOf:
           - contains:
               $ref: "@/tag/p.yaml"
-          - not:
-              contains:
-                type: array
-                minItems: 1
-                items:
-                  - const: "e"
-          - contains:
-              type: array
-              minItems: 2
-              items:
-                - const: "e"
-                - type: string
-                  pattern: "^[a-f0-9]{64}$"
+          - anyOf:
+              - not:
+                  contains:
+                    type: array
+                    minItems: 1
+                    items:
+                      - const: "e"
+              - contains:
+                  type: array
+                  minItems: 2
+                  items:
+                    - const: "e"
+                    - type: string
+                      pattern: "^[a-f0-9]{64}$"
         errorMessage:
           contains: "tags must include a p tag identifying the intended recipient"
     required:


### PR DESCRIPTION
 - add NIP-04 kind-4 encrypted direct message schema enforcing base note structure, base64
  content?...iv=... pattern, and required p tag (with optional validated e references) in nips/nip-04/kind-
  4/schema.yaml
  - supply validating and failing examples for schema checks in nips/nip-04/kind-4/samples/
