### PR TITLE
Add NIP-34 schemas for git collaboration

### DIFF
--- a/@/tag/applied-as-commits.yaml
+++ b/@/tag/applied-as-commits.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-34/tag/applied-as-commits/schema.yaml"

--- a/@/tag/clone.yaml
+++ b/@/tag/clone.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-34/tag/clone/schema.yaml"

--- a/@/tag/commit-pgp-sig.yaml
+++ b/@/tag/commit-pgp-sig.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-34/tag/commit-pgp-sig/schema.yaml"

--- a/@/tag/commit.yaml
+++ b/@/tag/commit.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-34/tag/commit/schema.yaml"

--- a/@/tag/committer.yaml
+++ b/@/tag/committer.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-34/tag/committer/schema.yaml"

--- a/@/tag/e-root.yaml
+++ b/@/tag/e-root.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-34/tag/e-root/schema.yaml"

--- a/@/tag/e-status-reply.yaml
+++ b/@/tag/e-status-reply.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-34/tag/e-status-reply/schema.yaml"

--- a/@/tag/git-ref.yaml
+++ b/@/tag/git-ref.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-34/tag/ref/schema.yaml"

--- a/@/tag/head.yaml
+++ b/@/tag/head.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-34/tag/head/schema.yaml"

--- a/@/tag/maintainers.yaml
+++ b/@/tag/maintainers.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-34/tag/maintainers/schema.yaml"

--- a/@/tag/merge-commit.yaml
+++ b/@/tag/merge-commit.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-34/tag/merge-commit/schema.yaml"

--- a/@/tag/name.yaml
+++ b/@/tag/name.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-34/tag/name/schema.yaml"

--- a/@/tag/parent-commit.yaml
+++ b/@/tag/parent-commit.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-34/tag/parent-commit/schema.yaml"

--- a/@/tag/r-euc.yaml
+++ b/@/tag/r-euc.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-34/tag/r-euc/schema.yaml"

--- a/@/tag/web.yaml
+++ b/@/tag/web.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-34/tag/web/schema.yaml"

--- a/nips/nip-34/kind-1617/schema.yaml
+++ b/nips/nip-34/kind-1617/schema.yaml
@@ -1,0 +1,59 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind1617
+description: NIP-34 patch event (git format-patch payload)
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 1617
+      content:
+        type: string
+        minLength: 1
+        description: "Patch contents as produced by git format-patch"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/a.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "commit"
+            then:
+              contains:
+                $ref: "@/tag/commit.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "parent-commit"
+            then:
+              contains:
+                $ref: "@/tag/parent-commit.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "commit-pgp-sig"
+            then:
+              contains:
+                $ref: "@/tag/commit-pgp-sig.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "committer"
+            then:
+              contains:
+                $ref: "@/tag/committer.yaml"
+        errorMessage:
+          contains: "tags must include required tag: a"
+    required:
+      - kind
+      - content
+      - tags

--- a/nips/nip-34/kind-1621/schema.yaml
+++ b/nips/nip-34/kind-1621/schema.yaml
@@ -1,0 +1,35 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind1621
+description: NIP-34 issue event (markdown discussion thread)
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 1621
+      content:
+        type: string
+        minLength: 1
+        description: "Issue body as Markdown text"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/a.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "subject"
+            then:
+              contains:
+                $ref: "@/tag/subject.yaml"
+        errorMessage:
+          contains: "tags must include required tag: a"
+    required:
+      - kind
+      - content
+      - tags

--- a/nips/nip-34/kind-1630/schema.yaml
+++ b/nips/nip-34/kind-1630/schema.yaml
@@ -1,0 +1,50 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind1630
+description: NIP-34 status event indicating Open state
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 1630
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/e-root.yaml"
+          - if:
+              contains:
+                type: array
+                minItems: 4
+                items:
+                  - const: "e"
+                  - type: string
+                  - {}
+                  - const: "reply"
+            then:
+              contains:
+                $ref: "@/tag/e-status-reply.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "merge-commit"
+            then:
+              contains:
+                $ref: "@/tag/merge-commit.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "applied-as-commits"
+            then:
+              contains:
+                $ref: "@/tag/applied-as-commits.yaml"
+        errorMessage:
+          contains: "tags must include an e tag referencing the root event"
+    required:
+      - kind
+      - tags

--- a/nips/nip-34/kind-1631/schema.yaml
+++ b/nips/nip-34/kind-1631/schema.yaml
@@ -1,0 +1,58 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind1631
+description: NIP-34 status event indicating Applied / Merged / Resolved state
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 1631
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/e-root.yaml"
+          - if:
+              contains:
+                type: array
+                minItems: 4
+                items:
+                  - const: "e"
+                  - type: string
+                  - {}
+                  - const: "reply"
+            then:
+              contains:
+                $ref: "@/tag/e-status-reply.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "merge-commit"
+            then:
+              contains:
+                $ref: "@/tag/merge-commit.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "applied-as-commits"
+            then:
+              contains:
+                $ref: "@/tag/applied-as-commits.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "commit"
+            then:
+              contains:
+                $ref: "@/tag/commit.yaml"
+        errorMessage:
+          contains: "tags must include an e tag referencing the root event"
+    required:
+      - kind
+      - tags

--- a/nips/nip-34/kind-1632/schema.yaml
+++ b/nips/nip-34/kind-1632/schema.yaml
@@ -1,0 +1,50 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind1632
+description: NIP-34 status event indicating Closed state
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 1632
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/e-root.yaml"
+          - if:
+              contains:
+                type: array
+                minItems: 4
+                items:
+                  - const: "e"
+                  - type: string
+                  - {}
+                  - const: "reply"
+            then:
+              contains:
+                $ref: "@/tag/e-status-reply.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "merge-commit"
+            then:
+              contains:
+                $ref: "@/tag/merge-commit.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "applied-as-commits"
+            then:
+              contains:
+                $ref: "@/tag/applied-as-commits.yaml"
+        errorMessage:
+          contains: "tags must include an e tag referencing the root event"
+    required:
+      - kind
+      - tags

--- a/nips/nip-34/kind-1633/schema.yaml
+++ b/nips/nip-34/kind-1633/schema.yaml
@@ -1,0 +1,50 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind1633
+description: NIP-34 status event indicating Draft state
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 1633
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/e-root.yaml"
+          - if:
+              contains:
+                type: array
+                minItems: 4
+                items:
+                  - const: "e"
+                  - type: string
+                  - {}
+                  - const: "reply"
+            then:
+              contains:
+                $ref: "@/tag/e-status-reply.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "merge-commit"
+            then:
+              contains:
+                $ref: "@/tag/merge-commit.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "applied-as-commits"
+            then:
+              contains:
+                $ref: "@/tag/applied-as-commits.yaml"
+        errorMessage:
+          contains: "tags must include an e tag referencing the root event"
+    required:
+      - kind
+      - tags

--- a/nips/nip-34/kind-30617/schema.yaml
+++ b/nips/nip-34/kind-30617/schema.yaml
@@ -1,0 +1,78 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind30617
+description: NIP-34 repository announcement event
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 30617
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/d.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "name"
+            then:
+              contains:
+                $ref: "@/tag/name.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "description"
+            then:
+              contains:
+                $ref: "@/tag/description.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "web"
+            then:
+              contains:
+                $ref: "@/tag/web.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "clone"
+            then:
+              contains:
+                $ref: "@/tag/clone.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "relays"
+            then:
+              contains:
+                $ref: "@/tag/relays.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "maintainers"
+            then:
+              contains:
+                $ref: "@/tag/maintainers.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "r"
+            then:
+              contains:
+                $ref: "@/tag/r-euc.yaml"
+        errorMessage:
+          contains: "tags must include required tag: d"
+    required:
+      - kind
+      - tags

--- a/nips/nip-34/kind-30618/schema.yaml
+++ b/nips/nip-34/kind-30618/schema.yaml
@@ -1,0 +1,39 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind30618
+description: NIP-34 repository state announcement event
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 30618
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/d.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - type: string
+                    pattern: '^refs/.*'
+            then:
+              contains:
+                $ref: "@/tag/git-ref.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "HEAD"
+            then:
+              contains:
+                $ref: "@/tag/head.yaml"
+        errorMessage:
+          contains: "tags must include required tag: d"
+    required:
+      - kind
+      - tags

--- a/nips/nip-34/tag/applied-as-commits/schema.yaml
+++ b/nips/nip-34/tag/applied-as-commits/schema.yaml
@@ -1,0 +1,12 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    items:
+      - const: "applied-as-commits"
+      - type: string
+        pattern: '^[a-f0-9]{7,40}$'
+    additionalItems:
+      type: string
+      pattern: '^[a-f0-9]{7,40}$'

--- a/nips/nip-34/tag/clone/schema.yaml
+++ b/nips/nip-34/tag/clone/schema.yaml
@@ -1,0 +1,13 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    description: "Git clone endpoints"
+    minItems: 2
+    items:
+      - const: "clone"
+      - type: string
+        pattern: '^(([a-z][a-z0-9+\.-]*://)|git@)[^\s]+$'
+    additionalItems:
+      type: string
+      pattern: '^(([a-z][a-z0-9+\.-]*://)|git@)[^\s]+$'

--- a/nips/nip-34/tag/commit-pgp-sig/schema.yaml
+++ b/nips/nip-34/tag/commit-pgp-sig/schema.yaml
@@ -1,0 +1,14 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "commit-pgp-sig"
+      - anyOf:
+          - type: string
+            const: ""
+          - type: string
+            pattern: '^-----BEGIN PGP SIGNATURE-----'
+    additionalItems: false

--- a/nips/nip-34/tag/commit-pgp-sig/schema.yaml
+++ b/nips/nip-34/tag/commit-pgp-sig/schema.yaml
@@ -10,5 +10,5 @@ allOf:
           - type: string
             const: ""
           - type: string
-            pattern: '^-----BEGIN PGP SIGNATURE-----'
+            pattern: '^\-\-\-\-\-BEGIN PGP SIGNATURE\-\-\-\-\-[\s\S]*\-\-\-\-\-END PGP SIGNATURE\-\-\-\-\-$'
     additionalItems: false

--- a/nips/nip-34/tag/commit/schema.yaml
+++ b/nips/nip-34/tag/commit/schema.yaml
@@ -1,0 +1,11 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "commit"
+      - type: string
+        pattern: '^[a-f0-9]{40}$'
+    additionalItems: false

--- a/nips/nip-34/tag/committer/schema.yaml
+++ b/nips/nip-34/tag/committer/schema.yaml
@@ -1,0 +1,17 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 5
+    maxItems: 5
+    items:
+      - const: "committer"
+      - type: string
+        minLength: 1
+      - type: string
+        pattern: '^[^\s@]+@[^\s@]+$'
+      - type: string
+        pattern: '^-?[0-9]+$'
+      - type: string
+        pattern: '^-?[0-9]+$'
+    additionalItems: false

--- a/nips/nip-34/tag/description/schema.yaml
+++ b/nips/nip-34/tag/description/schema.yaml
@@ -1,0 +1,11 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "description"
+      - type: string
+        minLength: 1
+    additionalItems: false

--- a/nips/nip-34/tag/e-root/schema.yaml
+++ b/nips/nip-34/tag/e-root/schema.yaml
@@ -1,0 +1,18 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    description: "Reference to the root patch or issue event"
+    minItems: 4
+    maxItems: 4
+    items:
+      - const: "e"
+      - type: string
+        pattern: '^[a-f0-9]{64}$'
+      - anyOf:
+          - type: string
+            const: ""
+          - type: string
+            pattern: '^(ws://|wss://).+$'
+      - const: "root"
+    additionalItems: false

--- a/nips/nip-34/tag/e-status-reply/schema.yaml
+++ b/nips/nip-34/tag/e-status-reply/schema.yaml
@@ -1,0 +1,18 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    description: "Reference to an accepted revision root event"
+    minItems: 4
+    maxItems: 4
+    items:
+      - const: "e"
+      - type: string
+        pattern: '^[a-f0-9]{64}$'
+      - anyOf:
+          - type: string
+            const: ""
+          - type: string
+            pattern: '^(ws://|wss://).+$'
+      - const: "reply"
+    additionalItems: false

--- a/nips/nip-34/tag/head/schema.yaml
+++ b/nips/nip-34/tag/head/schema.yaml
@@ -1,0 +1,12 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    description: "Repository HEAD reference"
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "HEAD"
+      - type: string
+        pattern: '^ref: refs/heads/[^\s]+$'
+    additionalItems: false

--- a/nips/nip-34/tag/maintainers/schema.yaml
+++ b/nips/nip-34/tag/maintainers/schema.yaml
@@ -1,0 +1,13 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    description: "Recognized maintainers for the repository"
+    minItems: 2
+    items:
+      - const: "maintainers"
+      - type: string
+        minLength: 1
+    additionalItems:
+      type: string
+      minLength: 1

--- a/nips/nip-34/tag/merge-commit/schema.yaml
+++ b/nips/nip-34/tag/merge-commit/schema.yaml
@@ -1,0 +1,11 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "merge-commit"
+      - type: string
+        pattern: '^[a-f0-9]{40}$'
+    additionalItems: false

--- a/nips/nip-34/tag/name/schema.yaml
+++ b/nips/nip-34/tag/name/schema.yaml
@@ -1,0 +1,11 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "name"
+      - type: string
+        minLength: 1
+    additionalItems: false

--- a/nips/nip-34/tag/parent-commit/schema.yaml
+++ b/nips/nip-34/tag/parent-commit/schema.yaml
@@ -1,0 +1,11 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "parent-commit"
+      - type: string
+        pattern: '^[a-f0-9]{40}$'
+    additionalItems: false

--- a/nips/nip-34/tag/r-euc/schema.yaml
+++ b/nips/nip-34/tag/r-euc/schema.yaml
@@ -1,0 +1,13 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    description: "Earliest unique commit identifier"
+    minItems: 3
+    maxItems: 3
+    items:
+      - const: "r"
+      - type: string
+        pattern: '^[a-f0-9]{40}$'
+      - const: "euc"
+    additionalItems: false

--- a/nips/nip-34/tag/ref/schema.yaml
+++ b/nips/nip-34/tag/ref/schema.yaml
@@ -1,0 +1,15 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    description: "Git reference state entry"
+    minItems: 3
+    items:
+      - const: "ref"
+      - type: string
+        pattern: '^refs\/(heads|tags)\/[^\s]+$'
+      - type: string
+        pattern: '^[a-f0-9]{7,40}$'
+    additionalItems:
+      type: string
+      pattern: '^[a-f0-9]{7,40}$'

--- a/nips/nip-34/tag/subject/schema.yaml
+++ b/nips/nip-34/tag/subject/schema.yaml
@@ -1,0 +1,11 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "subject"
+      - type: string
+        minLength: 1
+    additionalItems: false

--- a/nips/nip-34/tag/web/schema.yaml
+++ b/nips/nip-34/tag/web/schema.yaml
@@ -1,0 +1,13 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    description: "Repository browsing URLs"
+    minItems: 2
+    items:
+      - const: "web"
+      - type: string
+        pattern: '^(https?://).+$'
+    additionalItems:
+      type: string
+      pattern: '^(https?://).+$'


### PR DESCRIPTION
## Summary
- add schemas for NIP-34 event kinds and status updates
- add reusable tag aliases for repository metadata and git state
- enforce optional metadata structure for NIP-34 status, patch, and issue events

## Testing
- pnpm build
- pnpm test *(fails: vitest not found on runner)*