### PR TITLE
Add MIP-03 group event schema

### DIFF
--- a/@/mip/marmot-group-event.yaml
+++ b/@/mip/marmot-group-event.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/mip-03/kind-445/schema.yaml"

--- a/@/mip/marmot-welcome.yaml
+++ b/@/mip/marmot-welcome.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/mip-02/kind-444/schema.yaml"

--- a/nips/mip-02/kind-444/schema.yaml
+++ b/nips/mip-02/kind-444/schema.yaml
@@ -1,0 +1,54 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind444MarmotWelcome
+description: Unsigned Marmot Welcome event defined in MIP-02 and delivered via NIP-59 gift wrap.
+type: object
+additionalProperties: false
+properties:
+  id:
+    type: string
+    minLength: 64
+    maxLength: 64
+    pattern: '^[a-f0-9]{64}$'
+    description: 32-byte event identifier encoded as lowercase hex.
+    errorMessage:
+      pattern: id must be a 64 character lowercase hex string
+  pubkey:
+    allOf:
+      - $ref: "@/secp256k1.yaml"
+    description: Public key of the administrator sending the welcome.
+    errorMessage: pubkey must be the lowercase hex-encoded secp256k1 key of the sender
+  created_at:
+    type: integer
+    description: Unix timestamp, in seconds, when the welcome was produced.
+    errorMessage: created_at must be a unix timestamp expressed in seconds
+  kind:
+    const: 444
+    description: Event kind reserved for Marmot Welcome events (MIP-02).
+  content:
+    type: string
+    minLength: 2
+    pattern: '^(?:[0-9a-f]{2})+$'
+    description: Hex-encoded MLS Welcome object serialized as an MLSMessage.
+    errorMessage:
+      pattern: content must be a lowercase hex string representing the MLS Welcome payload
+      minLength: content must not be empty
+  tags:
+    type: array
+    items:
+      $ref: "@/tag.yaml"
+    minItems: 2
+    allOf:
+      - contains:
+          $ref: "@/tag/e.yaml"
+      - contains:
+          $ref: "@/tag/relays.yaml"
+    description: Tags MUST include both the referenced KeyPackage event (e tag) and relay hints for group traffic.
+    errorMessage:
+      contains: tags must include both an e tag referencing the key package event and a relays tag listing group relays
+required:
+  - id
+  - pubkey
+  - created_at
+  - kind
+  - content
+  - tags

--- a/nips/mip-03/kind-445/schema.yaml
+++ b/nips/mip-03/kind-445/schema.yaml
@@ -1,0 +1,37 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind445MarmotGroupEvent
+description: Marmot Protocol group event carrying encrypted MLS messages as defined in MIP-03.
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 445
+        description: Event kind reserved for Marmot group Proposal, Commit, and Application messages.
+      pubkey:
+        allOf:
+          - $ref: "@/secp256k1.yaml"
+        description: Ephemeral secp256k1 public key generated uniquely for each group event publication.
+        errorMessage: pubkey must be a lowercase hex-encoded secp256k1 public key
+      content:
+        type: string
+        minLength: 4
+        pattern: '^[A-Za-z0-9+/]+={0,2}$'
+        description: Base64-encoded NIP-44 ciphertext encapsulating the MLSMessage derived from the exporter_secret key material.
+        errorMessage:
+          pattern: content must be a base64 string containing the NIP-44 encrypted MLSMessage payload
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/h.yaml"
+        description: Tags MUST include the h tag containing the Marmot group identifier defined in MIP-01.
+        errorMessage:
+          contains: tags must include at least one h tag with the Marmot group identifier
+    required:
+      - kind
+      - content
+      - tags


### PR DESCRIPTION
## Summary
- add Marmot MIP-03 group event schema for kind 445
- expose @/mip/marmot-group-event alias for consumers
- accept base64 NIP-44 ciphertext per double-encryption flow

## Testing
- pnpm test
