### PR TITLE
add NIP-42 kind 22242 validation errors, valid and invalid samples, clarify challenge tag error message 

### DIFF
--- a/nips/nip-42/kind-22242/samples/invalid-content.json
+++ b/nips/nip-42/kind-22242/samples/invalid-content.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1712083200,
+  "kind": 22242,
+  "tags": [
+    ["relay", "wss://relay.example.com"],
+    ["challenge", "example-challenge-token"]
+  ],
+  "content": "example-challenge-token",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-42/kind-22242/samples/valid.json
+++ b/nips/nip-42/kind-22242/samples/valid.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1712083200,
+  "kind": 22242,
+  "tags": [
+    ["relay", "wss://relay.example.com"],
+    ["challenge", "example-challenge-token"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-42/kind-22242/schema.yaml
+++ b/nips/nip-42/kind-22242/schema.yaml
@@ -8,6 +8,11 @@ allOf:
       kind:
         const: 22242
         description: "Kind 22242 identifies an authentication event"
+        errorMessage: "kind must equal 22242"
+      content:
+        const: ""
+        description: "Content is always the empty string for NIP-42 authentication events"
+        errorMessage: "content must be empty for NIP-42 authentication events"
       tags:
         type: array
         items:

--- a/nips/nip-42/tag/challenge/schema.yaml
+++ b/nips/nip-42/tag/challenge/schema.yaml
@@ -10,5 +10,5 @@ allOf:
         minLength: 1
     additionalItems: false
     errorMessage:
-      minItems: "challenge tag must include the relay-provided string"
+      minItems: "challenge tag must include both tag name and challenge value"
       additionalItems: "challenge tag accepts only the name and challenge value"


### PR DESCRIPTION
## Summary
- enforce kind 22242 to use empty content with clear validation errors
- add valid and invalid samples for the NIP-42 auth event
- clarify the challenge tag length error message

## Testing
- pnpm test
