### PR TITLE
feat(nip-59): Add kind-13 seal and kind-1059 gift wrap schemas

### DIFF
--- a/nips/nip-59/kind-1059/schema.yaml
+++ b/nips/nip-59/kind-1059/schema.yaml
@@ -1,0 +1,30 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind1059
+description: Gift wrap event containing encrypted seal (NIP-59)
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 1059
+        description: "Kind 1059 identifies a gift wrap containing an encrypted seal"
+      pubkey:
+        allOf:
+          - $ref: "@/secp256k1.yaml"
+        description: "Ephemeral public key (not the sender's real pubkey)"
+      content:
+        type: string
+        minLength: 1
+        description: "NIP-44 encrypted JSON of the seal event"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/p.yaml"
+        errorMessage:
+          contains: "tags must include exactly one p tag identifying the recipient"
+    required:
+      - kind

--- a/nips/nip-59/kind-13/schema.yaml
+++ b/nips/nip-59/kind-13/schema.yaml
@@ -1,0 +1,21 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind13
+description: Seal event containing encrypted rumor (NIP-59)
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 13
+        description: "Kind 13 identifies a seal containing an encrypted rumor"
+      content:
+        type: string
+        minLength: 1
+        description: "NIP-44 encrypted JSON of the rumor event"
+      tags:
+        type: array
+        maxItems: 0
+        description: "Seals MUST NOT have any tags to avoid metadata leakage"
+        errorMessage: "seals must not contain any tags"
+    required:
+      - kind


### PR DESCRIPTION
## Summary

- Add JSON schemas for NIP-59 Gift Wrap protocol (kind-13 seal, kind-1059 gift wrap)
- Complements existing NIP-17 schemas (kind-14, kind-10050) for complete private DM validation

## Files Added

| File | Description |
|------|-------------|
| `nips/nip-59/kind-13/schema.yaml` | Seal event - encrypted rumor wrapper |
| `nips/nip-59/kind-1059/schema.yaml` | Gift wrap event - encrypted seal wrapper |

## Key Validations

**kind-13 (seal):**
- Requires NIP-44 encrypted content (`minLength: 1`)
- `maxItems: 0` on tags enforces "MUST NOT have any tags" per NIP-59 spec (metadata leakage prevention)

**kind-1059 (gift_wrap):**
- Ephemeral pubkey (documented, not validated as ephemeral)
- Requires NIP-44 encrypted content
- `contains: $ref: "@/tag/p.yaml"` ensures recipient p-tag is present

## References

- [NIP-59: Gift Wrap](https://github.com/nostr-protocol/nips/blob/master/59.md)
- [NIP-17: Private Direct Messages](https://github.com/nostr-protocol/nips/blob/master/17.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for gift-wrapped encrypted events with recipient identification
  * Added support for sealed encrypted events that prevent metadata leakage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->