### PR TITLE
Fix NIP-11 schema: invalid type null breaks AJV compilation

### DIFF
--- a/nips/nip-11/schema.yaml
+++ b/nips/nip-11/schema.yaml
@@ -191,5 +191,5 @@ allOf:
       time:
         anyOf:
           - type: number
-          - type: null
+          - type: "null"
     # additionalProperties: false


### PR DESCRIPTION
## Summary
- Fix `"type": null` (JSON null) to `"type": "null"` (string) in the NIP-11 schema's `retention.time` field
- This was causing AJV schema compilation to fail for all consumers of the NIP-11 schema

Closes #60

## Test plan
- [x] `pnpm build` succeeds
- [x] Built `dist/nips/nip-11/schema.json` contains `"type": "null"` (string) in both `retention.items` and `$defs.retent.time`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected schema definition for retention time to properly handle null values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->