### PR TITLE
fix: add id to note-unsigned base properties

### DIFF
--- a/nips/nip-01/note-unsigned/schema.yaml
+++ b/nips/nip-01/note-unsigned/schema.yaml
@@ -9,6 +9,11 @@ properties:
     type: integer
     errorMessage: "created_at must be a timestamp expressed in seconds (not milliseconds)"
     description: "The timestamp of the note creation"
+  id:
+    allOf:
+    - $ref: "@/secp256k1.yaml"
+    errorMessage: "id must be a valid hash"
+    description: "The id is a hash derived as specified in NIP-01"
   kind:
     type: integer
   pubkey:

--- a/nips/nip-17/kind-14/samples/invalid.has-sig.json
+++ b/nips/nip-17/kind-14/samples/invalid.has-sig.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1700000000,
+  "kind": 14,
+  "tags": [
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"]
+  ],
+  "content": "Hey, how are you?",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-17/kind-14/samples/invalid.missing-id.json
+++ b/nips/nip-17/kind-14/samples/invalid.missing-id.json
@@ -1,0 +1,9 @@
+{
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1700000000,
+  "kind": 14,
+  "tags": [
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"]
+  ],
+  "content": "Hey, how are you?"
+}

--- a/nips/nip-17/kind-14/samples/invalid.missing-p-tag.json
+++ b/nips/nip-17/kind-14/samples/invalid.missing-p-tag.json
@@ -1,0 +1,8 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1700000000,
+  "kind": 14,
+  "tags": [],
+  "content": "Hey, how are you?"
+}

--- a/nips/nip-17/kind-14/samples/valid.json
+++ b/nips/nip-17/kind-14/samples/valid.json
@@ -1,0 +1,10 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1700000000,
+  "kind": 14,
+  "tags": [
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"]
+  ],
+  "content": "Hey, how are you?"
+}

--- a/nips/nip-17/kind-15/samples/invalid.has-sig.json
+++ b/nips/nip-17/kind-15/samples/invalid.has-sig.json
@@ -1,0 +1,16 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1700000000,
+  "kind": 15,
+  "tags": [
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["file-type", "image/png"],
+    ["encryption-algorithm", "aes-gcm"],
+    ["decryption-key", "abc123def456"],
+    ["decryption-nonce", "nonce789"],
+    ["x", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"]
+  ],
+  "content": "https://example.com/encrypted-file.bin",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-17/kind-15/samples/invalid.missing-encryption-tags.json
+++ b/nips/nip-17/kind-15/samples/invalid.missing-encryption-tags.json
@@ -1,0 +1,10 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1700000000,
+  "kind": 15,
+  "tags": [
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"]
+  ],
+  "content": "https://example.com/encrypted-file.bin"
+}

--- a/nips/nip-17/kind-15/samples/invalid.missing-id.json
+++ b/nips/nip-17/kind-15/samples/invalid.missing-id.json
@@ -1,0 +1,14 @@
+{
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1700000000,
+  "kind": 15,
+  "tags": [
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["file-type", "image/png"],
+    ["encryption-algorithm", "aes-gcm"],
+    ["decryption-key", "abc123def456"],
+    ["decryption-nonce", "nonce789"],
+    ["x", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"]
+  ],
+  "content": "https://example.com/encrypted-file.bin"
+}

--- a/nips/nip-17/kind-15/samples/valid.json
+++ b/nips/nip-17/kind-15/samples/valid.json
@@ -1,0 +1,15 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1700000000,
+  "kind": 15,
+  "tags": [
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["file-type", "image/png"],
+    ["encryption-algorithm", "aes-gcm"],
+    ["decryption-key", "abc123def456"],
+    ["decryption-nonce", "nonce789"],
+    ["x", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"]
+  ],
+  "content": "https://example.com/encrypted-file.bin"
+}


### PR DESCRIPTION
## Summary

- Adds `id` to the `properties` in `note-unsigned` base schema, fixing the `additionalProperties: false` + `allOf` merging limitation in JSON Schema Draft-07
- Fixes kind 14 (NIP-17 private DM) and kind 15 (NIP-17 encrypted file message) schemas, which were unsatisfiable — `id` was rejected by the base as an additional property, but required by the kind overlay
- Mirrors the pattern already used in `note.yaml` (signed events), where `id` is declared in `properties`

Closes #62

## Test plan

- [x] `pnpm build` succeeds
- [x] All 31 existing sample tests pass (`pnpm test`)
- [x] Built kind 14 and kind 15 JSON schemas now include `id` in base properties
- [x] Validated with ajv (Node) and jsonschema (Python) that conforming kind 14/15 events now pass validation
- [x] Verified kind 13 and kind 1059 schemas remain unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notes now include ID validation to ensure IDs are valid hashes per NIP-01.

* **Documentation / Samples**
  * Added example event samples for NIP-17 kinds 14 and 15, including valid cases and invalid variants (missing id, missing required tags, and invalid signatures) to aid testing and reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->