### PR TITLE
feat: add MIP-00/02/03 schemas for Marmot protocol

### DIFF
--- a/@/tag/encoding.yaml
+++ b/@/tag/encoding.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "mips/mip-00/tag/encoding/schema.yaml"

--- a/@/tag/mls_ciphersuite.yaml
+++ b/@/tag/mls_ciphersuite.yaml
@@ -1,2 +1,2 @@
 allOf:
-  - $ref: "mips/mip-00/tag/ciphersuite/schema.yaml"
+  - $ref: "mips/mip-00/tag/mls_ciphersuite/schema.yaml"

--- a/@/tag/mls_extensions.yaml
+++ b/@/tag/mls_extensions.yaml
@@ -1,2 +1,2 @@
 allOf:
-  - $ref: "mips/mip-00/tag/extensions/schema.yaml"
+  - $ref: "mips/mip-00/tag/mls_extensions/schema.yaml"

--- a/@/tag/relays.yaml
+++ b/@/tag/relays.yaml
@@ -1,3 +1,2 @@
-allOf: 
+allOf:
   - $ref: "nips/nip-53/tag/relays/schema.yaml"
-

--- a/mips/mip-00/kind-443/schema.yaml
+++ b/mips/mip-00/kind-443/schema.yaml
@@ -10,15 +10,15 @@ allOf:
         description: "Kind number reserved for Marmot KeyPackage events"
       content:
         type: string
-        pattern: "^[0-9a-fA-F]+$"
-        minLength: 2
-        errorMessage: "content must be a hex-encoded MLS KeyPackage bundle"
-        description: "Hex-encoded TLS-serialized MLS KeyPackageBundle"
+        pattern: "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"
+        minLength: 48
+        errorMessage: "content must be a base64-encoded MLS KeyPackage bundle"
+        description: "Base64-encoded TLS-serialized MLS KeyPackageBundle"
       tags:
         type: array
         items:
           $ref: "@/tag.yaml"
-        minItems: 4
+        minItems: 6
         allOf:
           - contains:
               $ref: "@/tag/mls_protocol_version.yaml"
@@ -28,8 +28,12 @@ allOf:
               $ref: "@/tag/mls_extensions.yaml"
           - contains:
               $ref: "@/tag/relays.yaml"
+          - contains:
+              $ref: "@/tag/encoding.yaml"
+          - contains:
+              $ref: "mips/mip-00/tag/i/schema.yaml"
         errorMessage:
-          contains: "tags must include mls_protocol_version, ciphersuite, extensions, and relays tags"
+          contains: "tags must include mls_protocol_version, mls_ciphersuite, mls_extensions, relays, encoding, and i tags"
     required:
       - kind
       - tags

--- a/mips/mip-00/tag/encoding/schema.yaml
+++ b/mips/mip-00/tag/encoding/schema.yaml
@@ -1,12 +1,13 @@
 $schema: "http://json-schema.org/draft-07/schema#"
+title: Encoding
 allOf:
   - $ref: "@/tag.yaml"
   - type: array
     minItems: 2
     maxItems: 2
     items:
-      - const: "mls_protocol_version"
+      - const: "encoding"
       - type: string
-        pattern: "^[0-9]+(\\.[0-9]+)*$"
-        description: "MLS protocol version identifier"
+        enum: ["base64"]
+        description: "Content encoding format"
     additionalItems: false

--- a/mips/mip-00/tag/i/schema.yaml
+++ b/mips/mip-00/tag/i/schema.yaml
@@ -1,0 +1,16 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+title: KeyPackageRef
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "i"
+      - type: string
+        pattern: "^[a-f0-9]{64}$"
+        description: "Hex-encoded KeyPackageRef (SHA-256 hash of the KeyPackage)"
+    additionalItems: false
+    errorMessage:
+      minItems: "i tag must have exactly two elements: ['i', <KeyPackageRef>]"
+      maxItems: "i tag must have exactly two elements: ['i', <KeyPackageRef>]"

--- a/mips/mip-00/tag/mls_ciphersuite/schema.yaml
+++ b/mips/mip-00/tag/mls_ciphersuite/schema.yaml
@@ -1,11 +1,13 @@
 $schema: "http://json-schema.org/draft-07/schema#"
+title: MLS Ciphersuite
 allOf:
   - $ref: "@/tag.yaml"
   - type: array
     minItems: 2
     maxItems: 2
     items:
-      - const: "ciphersuite"
+      - const: "mls_ciphersuite"
       - type: string
         pattern: "^0x[0-9a-fA-F]{4}$"
         description: "MLS ciphersuite identifier in 0xXXXX format"
+    additionalItems: false

--- a/mips/mip-00/tag/mls_extensions/schema.yaml
+++ b/mips/mip-00/tag/mls_extensions/schema.yaml
@@ -3,8 +3,9 @@ allOf:
   - $ref: "@/tag.yaml"
   - type: array
     minItems: 2
+    uniqueItems: true
     items:
-      - const: "extensions"
+      - const: "mls_extensions"
       - type: string
         pattern: "^0x[0-9a-fA-F]{4}$"
         description: "MLS extension identifier"

--- a/mips/mip-02/kind-444/schema.yaml
+++ b/mips/mip-02/kind-444/schema.yaml
@@ -1,0 +1,45 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind444
+description: Marmot Welcome event — private group invitation delivered via NIP-59 gift-wrapping (MIP-02). This event is unsigned to prevent accidental public publishing.
+allOf:
+  - $ref: "@/note-unsigned.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 444
+        description: "Kind number for Marmot Welcome events"
+      id:
+        allOf:
+          - $ref: "@/secp256k1.yaml"
+        description: "Deterministic event hash as defined in NIP-01"
+      pubkey:
+        allOf:
+          - $ref: "@/secp256k1.yaml"
+        description: "Sender public key"
+      content:
+        type: string
+        pattern: "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"
+        minLength: 160
+        errorMessage: "content must be a base64-encoded MLS Welcome object (at least 160 characters)"
+        description: "Base64-encoded MLS Welcome object"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 3
+        allOf:
+          - contains:
+              $ref: "@/tag/e.yaml"
+          - contains:
+              $ref: "@/tag/relays.yaml"
+          - contains:
+              $ref: "@/tag/encoding.yaml"
+        errorMessage:
+          contains: "tags must include an e tag, relays, and encoding tags"
+    required:
+      - kind
+      - id
+      - pubkey
+  - not:
+      required:
+        - sig

--- a/mips/mip-03/kind-445/schema.yaml
+++ b/mips/mip-03/kind-445/schema.yaml
@@ -1,0 +1,29 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind445
+description: Marmot Group Event — encrypted container for all group communication including MLS control messages (Proposals/Commits) and application messages (MIP-03). Each event uses a fresh ephemeral Nostr keypair for unlinkability.
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 445
+        description: "Kind number for Marmot Group Events"
+      content:
+        type: string
+        pattern: "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"
+        minLength: 40
+        errorMessage: "content must be a base64-encoded encrypted payload"
+        description: "Base64-encoded payload: 12-byte nonce concatenated with ChaCha20-Poly1305 ciphertext"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        contains:
+          $ref: "mips/mip-03/tag/h/schema.yaml"
+        errorMessage:
+          contains: "tags must include an h tag with the hex-encoded nostr_group_id"
+    required:
+      - kind
+      - content
+      - tags

--- a/mips/mip-03/tag/h/schema.yaml
+++ b/mips/mip-03/tag/h/schema.yaml
@@ -5,8 +5,8 @@ allOf:
     minItems: 2
     maxItems: 2
     items:
-      - const: "mls_protocol_version"
+      - const: "h"
       - type: string
-        pattern: "^[0-9]+(\\.[0-9]+)*$"
-        description: "MLS protocol version identifier"
+        pattern: "^[a-f0-9]{64}$"
+        description: "Hex-encoded nostr_group_id (32-byte random identifier)"
     additionalItems: false

--- a/scripts/samples.spec.js
+++ b/scripts/samples.spec.js
@@ -23,15 +23,15 @@ function loadJSON(path) {
 const summary = { totalSuites: 0, totalCases: 0, passed: 0, failed: 0, failures: [] };
 const ajv = new Ajv({ allErrors: true, strict: false });
 
-// Scan all NIP schemas for samples
-for (const schemaDir of walkForSchemas('nips')) {
+// Scan all NIP and MIP schemas for samples
+for (const schemaDir of [...walkForSchemas('nips'), ...walkForSchemas('mips')]) {
   const samplesDir = join(schemaDir, 'samples');
   if (!existsSync(samplesDir)) continue;
   const rel = schemaDir.split(sep).join('/');
   const distSchema = `dist/${rel}/schema.json`;
   summary.totalSuites += 1;
 
-  describe(`Samples: ${rel.replace(/^nips\//, '')}`, () => {
+  describe(`Samples: ${rel.replace(/^(nips|mips)\//, '')}`, () => {
     if (!existsSync(distSchema)) {
       test.skip('schema not built yet', () => {});
       return;
@@ -48,15 +48,20 @@ for (const schemaDir of walkForSchemas('nips')) {
       test(`${name} should be ${expectValid ? 'valid' : 'invalid'}`, () => {
         const data = loadJSON(file);
         const ok = validate(data);
+        const testPassed = expectValid ? ok : !ok;
+        if (!testPassed) {
+          const errors = expectValid
+            ? validate.errors
+            : [{ message: 'expected invalid but validated' }];
+          summary.failures.push({ schema: rel, sample: name, errors });
+        }
+        summary.passed += testPassed ? 1 : 0;
+        summary.failed += testPassed ? 0 : 1;
         if (expectValid) {
-          if (!ok) summary.failures.push({ schema: rel, sample: name, errors: validate.errors });
           expect(ok).toBe(true);
         } else {
-          if (ok) summary.failures.push({ schema: rel, sample: name, errors: [{ message: 'expected invalid but validated' }] });
           expect(ok).toBe(false);
         }
-        summary.passed += ok ? 1 : 0;
-        summary.failed += ok ? 0 : 1;
       });
     }
   });


### PR DESCRIPTION
## Summary
- **MIP-00 fixes**: Align kind-443 with spec — base64 content (was hex), rename `ciphersuite`→`mls_ciphersuite` and `extensions`→`mls_extensions` tags, add required `encoding` and `i` (KeyPackageRef) tags
- **MIP-02 (new)**: Kind-444 unsigned Welcome event with `e`, `relays`, `encoding` tags — delivered via NIP-59 gift-wrapping
- **MIP-03 (new)**: Kind-445 encrypted Group Event with `h` tag (nostr_group_id) — uses ephemeral pubkeys for unlinkability
- **Infrastructure**: Fix test scanner to walk `mips/` directory, add `@/tag/` aliases for `mls_protocol_version`, `mls_ciphersuite`, `mls_extensions`, `relays`

MIP-01 has no Nostr event kinds (TLS binary extension format only) — nothing to schema-ize.

Spec reference: https://github.com/marmot-protocol/marmot

### Files changed

| File | Change |
|------|--------|
| `mips/mip-00/kind-443/schema.yaml` | Fix content pattern, add encoding+i tag requirements |
| `mips/mip-00/tag/mls_ciphersuite/` | Renamed from `ciphersuite/`, updated const |
| `mips/mip-00/tag/mls_extensions/` | Renamed from `extensions/`, updated const |
| `mips/mip-00/tag/encoding/schema.yaml` | New — `["encoding", "base64"]` |
| `mips/mip-00/tag/i/schema.yaml` | New — `["i", "<hex KeyPackageRef>"]` |
| `mips/mip-02/kind-444/schema.yaml` | New — unsigned Welcome event |
| `mips/mip-03/kind-445/schema.yaml` | New — encrypted Group Event |
| `mips/mip-03/tag/h/schema.yaml` | New — `["h", "<hex nostr_group_id>"]` |
| `@/tag/mls_*.yaml`, `@/tag/relays.yaml` | Aliases updated/created |
| `scripts/samples.spec.js` | Walk both `nips/` and `mips/` |

## Test plan
- [x] `pnpm build` — all schemas compile, `$id` correctly assigned (collisions handled: `mip-00_i`, `mip-00_client`)
- [x] `pnpm test` — 39/39 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two new event types for Welcome and Group workflows; added new tags: encoding, identity (i), mls_ciphersuite, mls_extensions, and h.

* **Improvements**
  * Switched MLS KeyPackage bundle encoding from hex to base64; raised min lengths and tightened patterns.
  * Stricter validation: exact item counts, disallowed extra items, unique entries, and expanded required tags.

* **Tests**
  * Test suite now scans both protocol sets and has improved pass/fail reporting and counters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->