### PR TITLE
fix: use explicit node path for yaml-convert in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ MIPS_DIR := mips
 ALIASES_DIR := @
 DIST_DIR := dist
 
-YAMLCONVERT := yaml-convert
+YAMLCONVERT := node $(realpath node_modules/yaml-convert/cli.js)
 REWRITE_SCRIPT := node $(realpath scripts/rewriteRefs.js)
 DEREF_SCRIPT := node $(realpath scripts/deref.js)
 


### PR DESCRIPTION
## Summary
- Fix `yaml-convert` invocation in Makefile to use explicit `node $(realpath ...)` path, matching the existing pattern for `REWRITE_SCRIPT` and `DEREF_SCRIPT`
- `make` spawns `/bin/sh` which does not have `node_modules/.bin` in PATH, causing `yaml-convert` to silently fail and `sed` to error on the missing output file

## Test plan
- [x] `make convert_json` succeeds — all 328 schemas convert, including `nip-88/tag/endsAt` and `nip-89/kind-31990`
- [x] `pnpm build` completes end-to-end (exit 0)
- [x] `pnpm test` — 172 passed, 0 failed

Fixes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to ensure proper invocation of YAML conversion utilities during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->