### PR TITLE
Add schemas for 7 remaining NIPs (25 kinds, 17 tags)

### DIFF
--- a/@/tag/amt.yaml
+++ b/@/tag/amt.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-69/tag/amt/schema.yaml"

--- a/@/tag/code.yaml
+++ b/@/tag/code.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-29/tag/code/schema.yaml"

--- a/@/tag/expires_at.yaml
+++ b/@/tag/expires_at.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-69/tag/expires_at/schema.yaml"

--- a/@/tag/f.yaml
+++ b/@/tag/f.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-69/tag/f/schema.yaml"

--- a/@/tag/fa.yaml
+++ b/@/tag/fa.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-69/tag/fa/schema.yaml"

--- a/@/tag/layer.yaml
+++ b/@/tag/layer.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-69/tag/layer/schema.yaml"

--- a/@/tag/m.yaml
+++ b/@/tag/m.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-94/tag/m/schema.yaml"

--- a/@/tag/method.yaml
+++ b/@/tag/method.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-98/tag/method/schema.yaml"

--- a/@/tag/network.yaml
+++ b/@/tag/network.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-69/tag/network/schema.yaml"

--- a/@/tag/nip-69_k.yaml
+++ b/@/tag/nip-69_k.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-69/tag/k/schema.yaml"

--- a/@/tag/ox.yaml
+++ b/@/tag/ox.yaml
@@ -1,2 +1,2 @@
 allOf:
-  - $ref: "nips/nip-17/tag/ox/schema.yaml"
+  - $ref: "nips/nip-94/tag/ox/schema.yaml"

--- a/@/tag/payload.yaml
+++ b/@/tag/payload.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-98/tag/payload/schema.yaml"

--- a/@/tag/pm.yaml
+++ b/@/tag/pm.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-69/tag/pm/schema.yaml"

--- a/@/tag/premium.yaml
+++ b/@/tag/premium.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-69/tag/premium/schema.yaml"

--- a/@/tag/s.yaml
+++ b/@/tag/s.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-69/tag/s/schema.yaml"

--- a/@/tag/url.yaml
+++ b/@/tag/url.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-94/tag/url/schema.yaml"

--- a/@/tag/y.yaml
+++ b/@/tag/y.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-69/tag/y/schema.yaml"

--- a/@/tag/z.yaml
+++ b/@/tag/z.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-69/tag/z/schema.yaml"

--- a/nips/nip-29/kind-39000/samples/invalid.missing-d-tag.json
+++ b/nips/nip-29/kind-39000/samples/invalid.missing-d-tag.json
@@ -1,0 +1,9 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 39000,
+  "tags": [],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-29/kind-39000/samples/valid.json
+++ b/nips/nip-29/kind-39000/samples/valid.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 39000,
+  "tags": [
+    ["d", "group-1"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-29/kind-39000/schema.yaml
+++ b/nips/nip-29/kind-39000/schema.yaml
@@ -1,0 +1,19 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind39000
+description: "Group metadata event defined by NIP-29"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 39000
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        allOf:
+          - contains:
+              $ref: "@/tag/d.yaml"
+    required:
+      - tags
+    additionalProperties: true

--- a/nips/nip-29/kind-39000/schema.yaml
+++ b/nips/nip-29/kind-39000/schema.yaml
@@ -14,6 +14,8 @@ allOf:
         allOf:
           - contains:
               $ref: "@/tag/d.yaml"
+            errorMessage:
+              contains: "tags must include a d tag"
     required:
       - tags
     additionalProperties: true

--- a/nips/nip-29/kind-39001/samples/invalid.missing-d-tag.json
+++ b/nips/nip-29/kind-39001/samples/invalid.missing-d-tag.json
@@ -1,0 +1,9 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 39001,
+  "tags": [],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-29/kind-39001/samples/valid.json
+++ b/nips/nip-29/kind-39001/samples/valid.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 39001,
+  "tags": [
+    ["d", "group-1"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-29/kind-39001/schema.yaml
+++ b/nips/nip-29/kind-39001/schema.yaml
@@ -1,0 +1,19 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind39001
+description: "Group admins event defined by NIP-29"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 39001
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        allOf:
+          - contains:
+              $ref: "@/tag/d.yaml"
+    required:
+      - tags
+    additionalProperties: true

--- a/nips/nip-29/kind-39001/schema.yaml
+++ b/nips/nip-29/kind-39001/schema.yaml
@@ -14,6 +14,8 @@ allOf:
         allOf:
           - contains:
               $ref: "@/tag/d.yaml"
+            errorMessage:
+              contains: "tags must include a d tag"
     required:
       - tags
     additionalProperties: true

--- a/nips/nip-29/kind-39002/samples/invalid.missing-d-tag.json
+++ b/nips/nip-29/kind-39002/samples/invalid.missing-d-tag.json
@@ -1,0 +1,9 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 39002,
+  "tags": [],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-29/kind-39002/samples/valid.json
+++ b/nips/nip-29/kind-39002/samples/valid.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 39002,
+  "tags": [
+    ["d", "group-1"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-29/kind-39002/schema.yaml
+++ b/nips/nip-29/kind-39002/schema.yaml
@@ -1,0 +1,19 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind39002
+description: "Group members event defined by NIP-29"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 39002
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        allOf:
+          - contains:
+              $ref: "@/tag/d.yaml"
+    required:
+      - tags
+    additionalProperties: true

--- a/nips/nip-29/kind-39002/schema.yaml
+++ b/nips/nip-29/kind-39002/schema.yaml
@@ -14,6 +14,8 @@ allOf:
         allOf:
           - contains:
               $ref: "@/tag/d.yaml"
+            errorMessage:
+              contains: "tags must include a d tag"
     required:
       - tags
     additionalProperties: true

--- a/nips/nip-29/kind-39003/samples/invalid.missing-d-tag.json
+++ b/nips/nip-29/kind-39003/samples/invalid.missing-d-tag.json
@@ -1,0 +1,9 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 39003,
+  "tags": [],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-29/kind-39003/samples/valid.json
+++ b/nips/nip-29/kind-39003/samples/valid.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 39003,
+  "tags": [
+    ["d", "group-1"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-29/kind-39003/schema.yaml
+++ b/nips/nip-29/kind-39003/schema.yaml
@@ -1,0 +1,19 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind39003
+description: "Group roles event defined by NIP-29"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 39003
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        allOf:
+          - contains:
+              $ref: "@/tag/d.yaml"
+    required:
+      - tags
+    additionalProperties: true

--- a/nips/nip-29/kind-39003/schema.yaml
+++ b/nips/nip-29/kind-39003/schema.yaml
@@ -14,6 +14,8 @@ allOf:
         allOf:
           - contains:
               $ref: "@/tag/d.yaml"
+            errorMessage:
+              contains: "tags must include a d tag"
     required:
       - tags
     additionalProperties: true

--- a/nips/nip-29/kind-9000/samples/invalid.missing-p-tag.json
+++ b/nips/nip-29/kind-9000/samples/invalid.missing-p-tag.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 9000,
+  "tags": [
+    ["h", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-29/kind-9000/samples/valid.json
+++ b/nips/nip-29/kind-9000/samples/valid.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 9000,
+  "tags": [
+    ["h", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"],
+    ["p", "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-29/kind-9000/schema.yaml
+++ b/nips/nip-29/kind-9000/schema.yaml
@@ -1,0 +1,20 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind9000
+description: "Put user event defined by NIP-29"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 9000
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        allOf:
+          - contains:
+              $ref: "@/tag/h.yaml"
+          - contains:
+              $ref: "@/tag/p.yaml"
+    required:
+      - tags

--- a/nips/nip-29/kind-9000/schema.yaml
+++ b/nips/nip-29/kind-9000/schema.yaml
@@ -14,7 +14,11 @@ allOf:
         allOf:
           - contains:
               $ref: "@/tag/h.yaml"
+            errorMessage:
+              contains: "tags must include an h tag with a group identifier"
           - contains:
               $ref: "@/tag/p.yaml"
+            errorMessage:
+              contains: "tags must include a p tag"
     required:
       - tags

--- a/nips/nip-29/kind-9001/samples/invalid.missing-p-tag.json
+++ b/nips/nip-29/kind-9001/samples/invalid.missing-p-tag.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 9001,
+  "tags": [
+    ["h", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-29/kind-9001/samples/valid.json
+++ b/nips/nip-29/kind-9001/samples/valid.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 9001,
+  "tags": [
+    ["h", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"],
+    ["p", "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-29/kind-9001/schema.yaml
+++ b/nips/nip-29/kind-9001/schema.yaml
@@ -14,7 +14,11 @@ allOf:
         allOf:
           - contains:
               $ref: "@/tag/h.yaml"
+            errorMessage:
+              contains: "tags must include an h tag with a group identifier"
           - contains:
               $ref: "@/tag/p.yaml"
+            errorMessage:
+              contains: "tags must include a p tag"
     required:
       - tags

--- a/nips/nip-29/kind-9001/schema.yaml
+++ b/nips/nip-29/kind-9001/schema.yaml
@@ -1,0 +1,20 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind9001
+description: "Remove user event defined by NIP-29"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 9001
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        allOf:
+          - contains:
+              $ref: "@/tag/h.yaml"
+          - contains:
+              $ref: "@/tag/p.yaml"
+    required:
+      - tags

--- a/nips/nip-29/kind-9002/samples/invalid.missing-h-tag.json
+++ b/nips/nip-29/kind-9002/samples/invalid.missing-h-tag.json
@@ -1,0 +1,9 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 9002,
+  "tags": [],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-29/kind-9002/samples/valid.json
+++ b/nips/nip-29/kind-9002/samples/valid.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 9002,
+  "tags": [
+    ["h", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-29/kind-9002/schema.yaml
+++ b/nips/nip-29/kind-9002/schema.yaml
@@ -1,0 +1,18 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind9002
+description: "Edit group metadata event defined by NIP-29"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 9002
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        allOf:
+          - contains:
+              $ref: "@/tag/h.yaml"
+    required:
+      - tags

--- a/nips/nip-29/kind-9002/schema.yaml
+++ b/nips/nip-29/kind-9002/schema.yaml
@@ -14,5 +14,7 @@ allOf:
         allOf:
           - contains:
               $ref: "@/tag/h.yaml"
+            errorMessage:
+              contains: "tags must include an h tag with a group identifier"
     required:
       - tags

--- a/nips/nip-29/kind-9005/samples/invalid.missing-e-tag.json
+++ b/nips/nip-29/kind-9005/samples/invalid.missing-e-tag.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 9005,
+  "tags": [
+    ["h", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-29/kind-9005/samples/valid.json
+++ b/nips/nip-29/kind-9005/samples/valid.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 9005,
+  "tags": [
+    ["h", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"],
+    ["e", "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-29/kind-9005/schema.yaml
+++ b/nips/nip-29/kind-9005/schema.yaml
@@ -14,7 +14,11 @@ allOf:
         allOf:
           - contains:
               $ref: "@/tag/h.yaml"
+            errorMessage:
+              contains: "tags must include an h tag with a group identifier"
           - contains:
               $ref: "@/tag/e.yaml"
+            errorMessage:
+              contains: "tags must include an e tag"
     required:
       - tags

--- a/nips/nip-29/kind-9005/schema.yaml
+++ b/nips/nip-29/kind-9005/schema.yaml
@@ -1,0 +1,20 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind9005
+description: "Delete event defined by NIP-29"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 9005
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        allOf:
+          - contains:
+              $ref: "@/tag/h.yaml"
+          - contains:
+              $ref: "@/tag/e.yaml"
+    required:
+      - tags

--- a/nips/nip-29/kind-9007/samples/invalid.missing-h-tag.json
+++ b/nips/nip-29/kind-9007/samples/invalid.missing-h-tag.json
@@ -1,0 +1,9 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 9007,
+  "tags": [],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-29/kind-9007/samples/valid.json
+++ b/nips/nip-29/kind-9007/samples/valid.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 9007,
+  "tags": [
+    ["h", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-29/kind-9007/schema.yaml
+++ b/nips/nip-29/kind-9007/schema.yaml
@@ -14,5 +14,7 @@ allOf:
         allOf:
           - contains:
               $ref: "@/tag/h.yaml"
+            errorMessage:
+              contains: "tags must include an h tag with a group identifier"
     required:
       - tags

--- a/nips/nip-29/kind-9007/schema.yaml
+++ b/nips/nip-29/kind-9007/schema.yaml
@@ -1,0 +1,18 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind9007
+description: "Create group event defined by NIP-29"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 9007
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        allOf:
+          - contains:
+              $ref: "@/tag/h.yaml"
+    required:
+      - tags

--- a/nips/nip-29/kind-9008/samples/invalid.missing-h-tag.json
+++ b/nips/nip-29/kind-9008/samples/invalid.missing-h-tag.json
@@ -1,0 +1,9 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 9008,
+  "tags": [],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-29/kind-9008/samples/valid.json
+++ b/nips/nip-29/kind-9008/samples/valid.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 9008,
+  "tags": [
+    ["h", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-29/kind-9008/schema.yaml
+++ b/nips/nip-29/kind-9008/schema.yaml
@@ -1,0 +1,18 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind9008
+description: "Delete group event defined by NIP-29"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 9008
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        allOf:
+          - contains:
+              $ref: "@/tag/h.yaml"
+    required:
+      - tags

--- a/nips/nip-29/kind-9008/schema.yaml
+++ b/nips/nip-29/kind-9008/schema.yaml
@@ -14,5 +14,7 @@ allOf:
         allOf:
           - contains:
               $ref: "@/tag/h.yaml"
+            errorMessage:
+              contains: "tags must include an h tag with a group identifier"
     required:
       - tags

--- a/nips/nip-29/kind-9009/samples/invalid.missing-code-tag.json
+++ b/nips/nip-29/kind-9009/samples/invalid.missing-code-tag.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 9009,
+  "tags": [
+    ["h", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-29/kind-9009/samples/valid.json
+++ b/nips/nip-29/kind-9009/samples/valid.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 9009,
+  "tags": [
+    ["h", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"],
+    ["code", "abc123"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-29/kind-9009/schema.yaml
+++ b/nips/nip-29/kind-9009/schema.yaml
@@ -14,7 +14,11 @@ allOf:
         allOf:
           - contains:
               $ref: "@/tag/h.yaml"
+            errorMessage:
+              contains: "tags must include an h tag with a group identifier"
           - contains:
               $ref: "@/tag/code.yaml"
+            errorMessage:
+              contains: "tags must include a code tag"
     required:
       - tags

--- a/nips/nip-29/kind-9009/schema.yaml
+++ b/nips/nip-29/kind-9009/schema.yaml
@@ -1,0 +1,20 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind9009
+description: "Create invite event defined by NIP-29"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 9009
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        allOf:
+          - contains:
+              $ref: "@/tag/h.yaml"
+          - contains:
+              $ref: "@/tag/code.yaml"
+    required:
+      - tags

--- a/nips/nip-29/kind-9021/samples/invalid.missing-h-tag.json
+++ b/nips/nip-29/kind-9021/samples/invalid.missing-h-tag.json
@@ -1,0 +1,9 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 9021,
+  "tags": [],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-29/kind-9021/samples/valid.json
+++ b/nips/nip-29/kind-9021/samples/valid.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 9021,
+  "tags": [
+    ["h", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-29/kind-9021/schema.yaml
+++ b/nips/nip-29/kind-9021/schema.yaml
@@ -1,0 +1,18 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind9021
+description: "Join request event defined by NIP-29"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 9021
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        allOf:
+          - contains:
+              $ref: "@/tag/h.yaml"
+    required:
+      - tags

--- a/nips/nip-29/kind-9021/schema.yaml
+++ b/nips/nip-29/kind-9021/schema.yaml
@@ -14,5 +14,7 @@ allOf:
         allOf:
           - contains:
               $ref: "@/tag/h.yaml"
+            errorMessage:
+              contains: "tags must include an h tag with a group identifier"
     required:
       - tags

--- a/nips/nip-29/kind-9022/samples/invalid.missing-h-tag.json
+++ b/nips/nip-29/kind-9022/samples/invalid.missing-h-tag.json
@@ -1,0 +1,9 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 9022,
+  "tags": [],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-29/kind-9022/samples/valid.json
+++ b/nips/nip-29/kind-9022/samples/valid.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 9022,
+  "tags": [
+    ["h", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-29/kind-9022/schema.yaml
+++ b/nips/nip-29/kind-9022/schema.yaml
@@ -1,0 +1,18 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind9022
+description: "Leave request event defined by NIP-29"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 9022
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        allOf:
+          - contains:
+              $ref: "@/tag/h.yaml"
+    required:
+      - tags

--- a/nips/nip-29/kind-9022/schema.yaml
+++ b/nips/nip-29/kind-9022/schema.yaml
@@ -14,5 +14,7 @@ allOf:
         allOf:
           - contains:
               $ref: "@/tag/h.yaml"
+            errorMessage:
+              contains: "tags must include an h tag with a group identifier"
     required:
       - tags

--- a/nips/nip-29/tag/code/schema.yaml
+++ b/nips/nip-29/tag/code/schema.yaml
@@ -1,0 +1,10 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "code"
+      - type: string
+    additionalItems: false

--- a/nips/nip-37/kind-10013/samples/invalid.wrong-kind.json
+++ b/nips/nip-37/kind-10013/samples/invalid.wrong-kind.json
@@ -1,0 +1,9 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 10014,
+  "tags": [],
+  "content": "encrypted-relay-list",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-37/kind-10013/samples/valid.json
+++ b/nips/nip-37/kind-10013/samples/valid.json
@@ -1,0 +1,9 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 10013,
+  "tags": [],
+  "content": "encrypted-relay-list",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-37/kind-10013/schema.yaml
+++ b/nips/nip-37/kind-10013/schema.yaml
@@ -1,0 +1,9 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind10013
+description: "Relay list for private content defined by NIP-37"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 10013

--- a/nips/nip-37/kind-31234/samples/invalid.missing-k-tag.json
+++ b/nips/nip-37/kind-31234/samples/invalid.missing-k-tag.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 31234,
+  "tags": [
+    ["d", "draft-1"]
+  ],
+  "content": "encrypted-draft-content",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-37/kind-31234/samples/valid.json
+++ b/nips/nip-37/kind-31234/samples/valid.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 31234,
+  "tags": [
+    ["d", "draft-1"],
+    ["k", "1"]
+  ],
+  "content": "encrypted-draft-content",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-37/kind-31234/schema.yaml
+++ b/nips/nip-37/kind-31234/schema.yaml
@@ -14,8 +14,12 @@ allOf:
         allOf:
           - contains:
               $ref: "@/tag/d.yaml"
+            errorMessage:
+              contains: "tags must include a d tag"
           - contains:
               $ref: "@/tag/k.yaml"
+            errorMessage:
+              contains: "tags must include a k tag identifying the draft event kind"
     required:
       - tags
     additionalProperties: true

--- a/nips/nip-37/kind-31234/schema.yaml
+++ b/nips/nip-37/kind-31234/schema.yaml
@@ -1,0 +1,21 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind31234
+description: "Draft event defined by NIP-37"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 31234
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        allOf:
+          - contains:
+              $ref: "@/tag/d.yaml"
+          - contains:
+              $ref: "@/tag/k.yaml"
+    required:
+      - tags
+    additionalProperties: true

--- a/nips/nip-60/kind-17375/samples/invalid.missing-mint-tag.json
+++ b/nips/nip-60/kind-17375/samples/invalid.missing-mint-tag.json
@@ -1,0 +1,9 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 17375,
+  "tags": [],
+  "content": "encrypted-wallet-data",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-60/kind-17375/samples/valid.json
+++ b/nips/nip-60/kind-17375/samples/valid.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 17375,
+  "tags": [
+    ["mint", "https://mint.example.com"]
+  ],
+  "content": "encrypted-wallet-data",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-60/kind-17375/schema.yaml
+++ b/nips/nip-60/kind-17375/schema.yaml
@@ -14,5 +14,7 @@ allOf:
         allOf:
           - contains:
               $ref: "@/tag/mint.yaml"
+            errorMessage:
+              contains: "tags must include a mint tag"
     required:
       - tags

--- a/nips/nip-60/kind-17375/schema.yaml
+++ b/nips/nip-60/kind-17375/schema.yaml
@@ -1,0 +1,18 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind17375
+description: "Wallet event defined by NIP-60"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 17375
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        allOf:
+          - contains:
+              $ref: "@/tag/mint.yaml"
+    required:
+      - tags

--- a/nips/nip-60/kind-7374/samples/invalid.missing-mint-tag.json
+++ b/nips/nip-60/kind-7374/samples/invalid.missing-mint-tag.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 7374,
+  "tags": [
+    ["expiration", "1670100000"]
+  ],
+  "content": "encrypted-quote-data",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-60/kind-7374/samples/valid.json
+++ b/nips/nip-60/kind-7374/samples/valid.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 7374,
+  "tags": [
+    ["expiration", "1670100000"],
+    ["mint", "https://mint.example.com"]
+  ],
+  "content": "encrypted-quote-data",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-60/kind-7374/schema.yaml
+++ b/nips/nip-60/kind-7374/schema.yaml
@@ -14,7 +14,11 @@ allOf:
         allOf:
           - contains:
               $ref: "@/tag/expiration.yaml"
+            errorMessage:
+              contains: "tags must include an expiration tag"
           - contains:
               $ref: "@/tag/mint.yaml"
+            errorMessage:
+              contains: "tags must include a mint tag"
     required:
       - tags

--- a/nips/nip-60/kind-7374/schema.yaml
+++ b/nips/nip-60/kind-7374/schema.yaml
@@ -1,0 +1,20 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind7374
+description: "Quote state event defined by NIP-60"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 7374
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        allOf:
+          - contains:
+              $ref: "@/tag/expiration.yaml"
+          - contains:
+              $ref: "@/tag/mint.yaml"
+    required:
+      - tags

--- a/nips/nip-60/kind-7375/samples/invalid.wrong-kind.json
+++ b/nips/nip-60/kind-7375/samples/invalid.wrong-kind.json
@@ -1,0 +1,9 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 7376,
+  "tags": [],
+  "content": "encrypted-token-data",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-60/kind-7375/samples/valid.json
+++ b/nips/nip-60/kind-7375/samples/valid.json
@@ -1,0 +1,9 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 7375,
+  "tags": [],
+  "content": "encrypted-token-data",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-60/kind-7375/schema.yaml
+++ b/nips/nip-60/kind-7375/schema.yaml
@@ -1,0 +1,9 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind7375
+description: "Token event defined by NIP-60"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 7375

--- a/nips/nip-69/kind-38383/samples/invalid.missing-s-tag.json
+++ b/nips/nip-69/kind-38383/samples/invalid.missing-s-tag.json
@@ -1,0 +1,23 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 38383,
+  "tags": [
+    ["d", "order-1"],
+    ["k", "sell"],
+    ["f", "USD"],
+    ["amt", "100000"],
+    ["fa", "50"],
+    ["pm", "bank-transfer"],
+    ["premium", "3"],
+    ["network", "mainnet"],
+    ["layer", "lightning"],
+    ["expires_at", "1670100000"],
+    ["expiration", "1670100000"],
+    ["y", "mostro"],
+    ["z", "order"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-69/kind-38383/samples/valid.json
+++ b/nips/nip-69/kind-38383/samples/valid.json
@@ -1,0 +1,24 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 38383,
+  "tags": [
+    ["d", "order-1"],
+    ["k", "sell"],
+    ["f", "USD"],
+    ["s", "pending"],
+    ["amt", "100000"],
+    ["fa", "50"],
+    ["pm", "bank-transfer"],
+    ["premium", "3"],
+    ["network", "mainnet"],
+    ["layer", "lightning"],
+    ["expires_at", "1670100000"],
+    ["expiration", "1670100000"],
+    ["y", "mostro"],
+    ["z", "order"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-69/kind-38383/schema.yaml
+++ b/nips/nip-69/kind-38383/schema.yaml
@@ -14,32 +14,60 @@ allOf:
         allOf:
           - contains:
               $ref: "@/tag/d.yaml"
+            errorMessage:
+              contains: "tags must include a d tag"
           - contains:
               $ref: "@/tag/nip-69_k.yaml"
+            errorMessage:
+              contains: "tags must include a k tag with order type"
           - contains:
               $ref: "@/tag/f.yaml"
+            errorMessage:
+              contains: "tags must include an f tag with currency code"
           - contains:
               $ref: "@/tag/s.yaml"
+            errorMessage:
+              contains: "tags must include an s tag with order status"
           - contains:
               $ref: "@/tag/amt.yaml"
+            errorMessage:
+              contains: "tags must include an amt tag with amount in satoshis"
           - contains:
               $ref: "@/tag/fa.yaml"
+            errorMessage:
+              contains: "tags must include an fa tag with fiat amount"
           - contains:
               $ref: "@/tag/pm.yaml"
+            errorMessage:
+              contains: "tags must include a pm tag with payment method"
           - contains:
               $ref: "@/tag/premium.yaml"
+            errorMessage:
+              contains: "tags must include a premium tag"
           - contains:
               $ref: "@/tag/network.yaml"
+            errorMessage:
+              contains: "tags must include a network tag"
           - contains:
               $ref: "@/tag/layer.yaml"
+            errorMessage:
+              contains: "tags must include a layer tag"
           - contains:
               $ref: "@/tag/expires_at.yaml"
+            errorMessage:
+              contains: "tags must include an expires_at tag"
           - contains:
               $ref: "@/tag/expiration.yaml"
+            errorMessage:
+              contains: "tags must include an expiration tag"
           - contains:
               $ref: "@/tag/y.yaml"
+            errorMessage:
+              contains: "tags must include a y tag with platform identifier"
           - contains:
               $ref: "@/tag/z.yaml"
+            errorMessage:
+              contains: "tags must include a z tag"
     required:
       - tags
     additionalProperties: true

--- a/nips/nip-69/kind-38383/schema.yaml
+++ b/nips/nip-69/kind-38383/schema.yaml
@@ -1,0 +1,45 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind38383
+description: "Peer-to-peer order event defined by NIP-69"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 38383
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        allOf:
+          - contains:
+              $ref: "@/tag/d.yaml"
+          - contains:
+              $ref: "@/tag/nip-69_k.yaml"
+          - contains:
+              $ref: "@/tag/f.yaml"
+          - contains:
+              $ref: "@/tag/s.yaml"
+          - contains:
+              $ref: "@/tag/amt.yaml"
+          - contains:
+              $ref: "@/tag/fa.yaml"
+          - contains:
+              $ref: "@/tag/pm.yaml"
+          - contains:
+              $ref: "@/tag/premium.yaml"
+          - contains:
+              $ref: "@/tag/network.yaml"
+          - contains:
+              $ref: "@/tag/layer.yaml"
+          - contains:
+              $ref: "@/tag/expires_at.yaml"
+          - contains:
+              $ref: "@/tag/expiration.yaml"
+          - contains:
+              $ref: "@/tag/y.yaml"
+          - contains:
+              $ref: "@/tag/z.yaml"
+    required:
+      - tags
+    additionalProperties: true

--- a/nips/nip-69/tag/amt/schema.yaml
+++ b/nips/nip-69/tag/amt/schema.yaml
@@ -1,0 +1,11 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "amt"
+      - type: string
+        pattern: '^[0-9]+$'
+    additionalItems: false

--- a/nips/nip-69/tag/expires_at/schema.yaml
+++ b/nips/nip-69/tag/expires_at/schema.yaml
@@ -1,0 +1,11 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "expires_at"
+      - type: string
+        pattern: '^[0-9]+$'
+    additionalItems: false

--- a/nips/nip-69/tag/f/schema.yaml
+++ b/nips/nip-69/tag/f/schema.yaml
@@ -1,0 +1,10 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "f"
+      - type: string
+    additionalItems: false

--- a/nips/nip-69/tag/fa/schema.yaml
+++ b/nips/nip-69/tag/fa/schema.yaml
@@ -1,0 +1,9 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    items:
+      - const: "fa"
+      - type: string
+    additionalItems: true

--- a/nips/nip-69/tag/k/schema.yaml
+++ b/nips/nip-69/tag/k/schema.yaml
@@ -1,0 +1,11 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "k"
+      - type: string
+        enum: ["sell", "buy"]
+    additionalItems: false

--- a/nips/nip-69/tag/layer/schema.yaml
+++ b/nips/nip-69/tag/layer/schema.yaml
@@ -1,0 +1,11 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "layer"
+      - type: string
+        enum: ["onchain", "lightning", "liquid"]
+    additionalItems: false

--- a/nips/nip-69/tag/network/schema.yaml
+++ b/nips/nip-69/tag/network/schema.yaml
@@ -1,0 +1,11 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "network"
+      - type: string
+        enum: ["mainnet", "testnet", "signet"]
+    additionalItems: false

--- a/nips/nip-69/tag/pm/schema.yaml
+++ b/nips/nip-69/tag/pm/schema.yaml
@@ -1,0 +1,9 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    items:
+      - const: "pm"
+      - type: string
+    additionalItems: true

--- a/nips/nip-69/tag/premium/schema.yaml
+++ b/nips/nip-69/tag/premium/schema.yaml
@@ -1,0 +1,10 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "premium"
+      - type: string
+    additionalItems: false

--- a/nips/nip-69/tag/s/schema.yaml
+++ b/nips/nip-69/tag/s/schema.yaml
@@ -1,0 +1,11 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "s"
+      - type: string
+        enum: ["pending", "canceled", "in-progress", "success", "expired"]
+    additionalItems: false

--- a/nips/nip-69/tag/y/schema.yaml
+++ b/nips/nip-69/tag/y/schema.yaml
@@ -1,0 +1,10 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "y"
+      - type: string
+    additionalItems: false

--- a/nips/nip-69/tag/z/schema.yaml
+++ b/nips/nip-69/tag/z/schema.yaml
@@ -1,0 +1,11 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "z"
+      - type: string
+        const: "order"
+    additionalItems: false

--- a/nips/nip-71/kind-21/samples/invalid.malformed-imeta.json
+++ b/nips/nip-71/kind-21/samples/invalid.malformed-imeta.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 21,
+  "tags": [
+    ["title", "My Video"],
+    ["imeta", "foo"]
+  ],
+  "content": "A short video description",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-71/kind-21/samples/invalid.missing-imeta.json
+++ b/nips/nip-71/kind-21/samples/invalid.missing-imeta.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 21,
+  "tags": [
+    ["title", "My Video"]
+  ],
+  "content": "A short video description",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-71/kind-21/samples/valid.json
+++ b/nips/nip-71/kind-21/samples/valid.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 21,
+  "tags": [
+    ["title", "My Video"],
+    ["imeta", "url https://example.com/video.mp4", "m video/mp4", "dim 1920x1080"]
+  ],
+  "content": "A short video description",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-71/kind-21/schema.yaml
+++ b/nips/nip-71/kind-21/schema.yaml
@@ -1,0 +1,21 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind21
+description: "Horizontal video event defined by NIP-71"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 21
+      tags:
+        allOf:
+          - contains:
+              $ref: "@/tag/title.yaml"
+          - contains:
+              allOf:
+                - $ref: "@/tag.yaml"
+                - type: array
+                  minItems: 2
+                  items:
+                    - const: "imeta"
+                  additionalItems: true

--- a/nips/nip-71/kind-21/schema.yaml
+++ b/nips/nip-71/kind-21/schema.yaml
@@ -11,5 +11,9 @@ allOf:
         allOf:
           - contains:
               $ref: "@/tag/title.yaml"
+            errorMessage:
+              contains: "tags must include a title tag"
           - contains:
               $ref: "nips/nip-71/tag/imeta/schema.yaml"
+            errorMessage:
+              contains: "tags must include an imeta tag with video metadata"

--- a/nips/nip-71/kind-21/schema.yaml
+++ b/nips/nip-71/kind-21/schema.yaml
@@ -12,10 +12,4 @@ allOf:
           - contains:
               $ref: "@/tag/title.yaml"
           - contains:
-              allOf:
-                - $ref: "@/tag.yaml"
-                - type: array
-                  minItems: 2
-                  items:
-                    - const: "imeta"
-                  additionalItems: true
+              $ref: "nips/nip-71/tag/imeta/schema.yaml"

--- a/nips/nip-71/kind-22/samples/invalid.missing-imeta.json
+++ b/nips/nip-71/kind-22/samples/invalid.missing-imeta.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 22,
+  "tags": [
+    ["title", "My Short"]
+  ],
+  "content": "A vertical video",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-71/kind-22/samples/valid.json
+++ b/nips/nip-71/kind-22/samples/valid.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 22,
+  "tags": [
+    ["title", "My Short"],
+    ["imeta", "url https://example.com/short.mp4", "m video/mp4", "dim 1080x1920"]
+  ],
+  "content": "A vertical video",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-71/kind-22/schema.yaml
+++ b/nips/nip-71/kind-22/schema.yaml
@@ -1,0 +1,21 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind22
+description: "Vertical video event defined by NIP-71"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 22
+      tags:
+        allOf:
+          - contains:
+              $ref: "@/tag/title.yaml"
+          - contains:
+              allOf:
+                - $ref: "@/tag.yaml"
+                - type: array
+                  minItems: 2
+                  items:
+                    - const: "imeta"
+                  additionalItems: true

--- a/nips/nip-71/kind-22/schema.yaml
+++ b/nips/nip-71/kind-22/schema.yaml
@@ -11,5 +11,9 @@ allOf:
         allOf:
           - contains:
               $ref: "@/tag/title.yaml"
+            errorMessage:
+              contains: "tags must include a title tag"
           - contains:
               $ref: "nips/nip-71/tag/imeta/schema.yaml"
+            errorMessage:
+              contains: "tags must include an imeta tag with video metadata"

--- a/nips/nip-71/kind-22/schema.yaml
+++ b/nips/nip-71/kind-22/schema.yaml
@@ -12,10 +12,4 @@ allOf:
           - contains:
               $ref: "@/tag/title.yaml"
           - contains:
-              allOf:
-                - $ref: "@/tag.yaml"
-                - type: array
-                  minItems: 2
-                  items:
-                    - const: "imeta"
-                  additionalItems: true
+              $ref: "nips/nip-71/tag/imeta/schema.yaml"

--- a/nips/nip-71/kind-34235/samples/invalid.missing-title.json
+++ b/nips/nip-71/kind-34235/samples/invalid.missing-title.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 34235,
+  "tags": [
+    ["d", "video-1"],
+    ["imeta", "url https://example.com/doc.mp4", "m video/mp4", "dim 1920x1080"]
+  ],
+  "content": "A documentary about nature",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-71/kind-34235/samples/valid.json
+++ b/nips/nip-71/kind-34235/samples/valid.json
@@ -1,0 +1,13 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 34235,
+  "tags": [
+    ["d", "video-1"],
+    ["title", "My Documentary"],
+    ["imeta", "url https://example.com/doc.mp4", "m video/mp4", "dim 1920x1080"]
+  ],
+  "content": "A documentary about nature",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-71/kind-34235/schema.yaml
+++ b/nips/nip-71/kind-34235/schema.yaml
@@ -1,0 +1,29 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind34235
+description: "Updatable horizontal video event defined by NIP-71"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 34235
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        allOf:
+          - contains:
+              $ref: "@/tag/d.yaml"
+          - contains:
+              $ref: "@/tag/title.yaml"
+          - contains:
+              allOf:
+                - $ref: "@/tag.yaml"
+                - type: array
+                  minItems: 2
+                  items:
+                    - const: "imeta"
+                  additionalItems: true
+    required:
+      - tags
+    additionalProperties: true

--- a/nips/nip-71/kind-34235/schema.yaml
+++ b/nips/nip-71/kind-34235/schema.yaml
@@ -17,13 +17,7 @@ allOf:
           - contains:
               $ref: "@/tag/title.yaml"
           - contains:
-              allOf:
-                - $ref: "@/tag.yaml"
-                - type: array
-                  minItems: 2
-                  items:
-                    - const: "imeta"
-                  additionalItems: true
+              $ref: "nips/nip-71/tag/imeta/schema.yaml"
     required:
       - tags
     additionalProperties: true

--- a/nips/nip-71/kind-34235/schema.yaml
+++ b/nips/nip-71/kind-34235/schema.yaml
@@ -14,10 +14,16 @@ allOf:
         allOf:
           - contains:
               $ref: "@/tag/d.yaml"
+            errorMessage:
+              contains: "tags must include a d tag"
           - contains:
               $ref: "@/tag/title.yaml"
+            errorMessage:
+              contains: "tags must include a title tag"
           - contains:
               $ref: "nips/nip-71/tag/imeta/schema.yaml"
+            errorMessage:
+              contains: "tags must include an imeta tag with video metadata"
     required:
       - tags
     additionalProperties: true

--- a/nips/nip-71/kind-34236/samples/invalid.missing-title.json
+++ b/nips/nip-71/kind-34236/samples/invalid.missing-title.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 34236,
+  "tags": [
+    ["d", "short-1"],
+    ["imeta", "url https://example.com/reel.mp4", "m video/mp4", "dim 1080x1920"]
+  ],
+  "content": "A short reel",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-71/kind-34236/samples/valid.json
+++ b/nips/nip-71/kind-34236/samples/valid.json
@@ -1,0 +1,13 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 34236,
+  "tags": [
+    ["d", "short-1"],
+    ["title", "My Reel"],
+    ["imeta", "url https://example.com/reel.mp4", "m video/mp4", "dim 1080x1920"]
+  ],
+  "content": "A short reel",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-71/kind-34236/schema.yaml
+++ b/nips/nip-71/kind-34236/schema.yaml
@@ -1,0 +1,29 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind34236
+description: "Updatable vertical video event defined by NIP-71"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 34236
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        allOf:
+          - contains:
+              $ref: "@/tag/d.yaml"
+          - contains:
+              $ref: "@/tag/title.yaml"
+          - contains:
+              allOf:
+                - $ref: "@/tag.yaml"
+                - type: array
+                  minItems: 2
+                  items:
+                    - const: "imeta"
+                  additionalItems: true
+    required:
+      - tags
+    additionalProperties: true

--- a/nips/nip-71/kind-34236/schema.yaml
+++ b/nips/nip-71/kind-34236/schema.yaml
@@ -17,13 +17,7 @@ allOf:
           - contains:
               $ref: "@/tag/title.yaml"
           - contains:
-              allOf:
-                - $ref: "@/tag.yaml"
-                - type: array
-                  minItems: 2
-                  items:
-                    - const: "imeta"
-                  additionalItems: true
+              $ref: "nips/nip-71/tag/imeta/schema.yaml"
     required:
       - tags
     additionalProperties: true

--- a/nips/nip-71/kind-34236/schema.yaml
+++ b/nips/nip-71/kind-34236/schema.yaml
@@ -14,10 +14,16 @@ allOf:
         allOf:
           - contains:
               $ref: "@/tag/d.yaml"
+            errorMessage:
+              contains: "tags must include a d tag"
           - contains:
               $ref: "@/tag/title.yaml"
+            errorMessage:
+              contains: "tags must include a title tag"
           - contains:
               $ref: "nips/nip-71/tag/imeta/schema.yaml"
+            errorMessage:
+              contains: "tags must include an imeta tag with video metadata"
     required:
       - tags
     additionalProperties: true

--- a/nips/nip-71/tag/imeta/schema.yaml
+++ b/nips/nip-71/tag/imeta/schema.yaml
@@ -1,0 +1,16 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+title: video imeta tag
+description: "NIP-71 metadata describing a video attachment"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    items:
+      - const: "imeta"
+      - type: string
+    additionalItems:
+      type: string
+    allOf:
+      - contains:
+          type: string
+          pattern: "^url https?://\\S+$"

--- a/nips/nip-94/kind-1063/samples/invalid.missing-url-tag.json
+++ b/nips/nip-94/kind-1063/samples/invalid.missing-url-tag.json
@@ -1,0 +1,13 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1063,
+  "tags": [
+    ["m", "image/jpeg"],
+    ["x", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"],
+    ["ox", "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"]
+  ],
+  "content": "A beautiful landscape photo",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-94/kind-1063/samples/valid.json
+++ b/nips/nip-94/kind-1063/samples/valid.json
@@ -1,0 +1,14 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1063,
+  "tags": [
+    ["url", "https://example.com/files/photo.jpg"],
+    ["m", "image/jpeg"],
+    ["x", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"],
+    ["ox", "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"]
+  ],
+  "content": "A beautiful landscape photo",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-94/kind-1063/schema.yaml
+++ b/nips/nip-94/kind-1063/schema.yaml
@@ -14,11 +14,19 @@ allOf:
         allOf:
           - contains:
               $ref: "@/tag/url.yaml"
+            errorMessage:
+              contains: "tags must include a url tag"
           - contains:
               $ref: "@/tag/m.yaml"
+            errorMessage:
+              contains: "tags must include an m tag with MIME type"
           - contains:
               $ref: "@/tag/x.yaml"
+            errorMessage:
+              contains: "tags must include an x tag with SHA-256 hash"
           - contains:
               $ref: "@/tag/ox.yaml"
+            errorMessage:
+              contains: "tags must include an ox tag with original file hash"
     required:
       - tags

--- a/nips/nip-94/kind-1063/schema.yaml
+++ b/nips/nip-94/kind-1063/schema.yaml
@@ -1,0 +1,24 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind1063
+description: "File metadata event defined by NIP-94"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 1063
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        allOf:
+          - contains:
+              $ref: "@/tag/url.yaml"
+          - contains:
+              $ref: "@/tag/m.yaml"
+          - contains:
+              $ref: "@/tag/x.yaml"
+          - contains:
+              $ref: "@/tag/ox.yaml"
+    required:
+      - tags

--- a/nips/nip-94/tag/m/schema.yaml
+++ b/nips/nip-94/tag/m/schema.yaml
@@ -7,5 +7,5 @@ allOf:
     items:
       - const: "m"
       - type: string
-        pattern: '^[a-z]+/[a-z0-9.+]+$'
+        pattern: '^[a-z]+/[a-z0-9.+-]+$'
     additionalItems: false

--- a/nips/nip-94/tag/m/schema.yaml
+++ b/nips/nip-94/tag/m/schema.yaml
@@ -1,0 +1,11 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "m"
+      - type: string
+        pattern: '^[a-z]+/[a-z0-9.+]+$'
+    additionalItems: false

--- a/nips/nip-94/tag/ox/schema.yaml
+++ b/nips/nip-94/tag/ox/schema.yaml
@@ -1,0 +1,11 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "ox"
+      - type: string
+        pattern: '^[a-f0-9]{64}$'
+    additionalItems: false

--- a/nips/nip-94/tag/url/schema.yaml
+++ b/nips/nip-94/tag/url/schema.yaml
@@ -1,0 +1,11 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "url"
+      - type: string
+        pattern: '^https?://.+$'
+    additionalItems: false

--- a/nips/nip-98/kind-27235/samples/invalid.missing-method-tag.json
+++ b/nips/nip-98/kind-27235/samples/invalid.missing-method-tag.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 27235,
+  "tags": [
+    ["u", "https://example.com/api/upload"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-98/kind-27235/samples/valid.json
+++ b/nips/nip-98/kind-27235/samples/valid.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 27235,
+  "tags": [
+    ["u", "https://example.com/api/upload"],
+    ["method", "POST"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-98/kind-27235/samples/valid.with-payload.json
+++ b/nips/nip-98/kind-27235/samples/valid.with-payload.json
@@ -1,0 +1,13 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 27235,
+  "tags": [
+    ["u", "https://example.com/api/upload"],
+    ["method", "POST"],
+    ["payload", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-98/kind-27235/schema.yaml
+++ b/nips/nip-98/kind-27235/schema.yaml
@@ -14,7 +14,11 @@ allOf:
         allOf:
           - contains:
               $ref: "@/tag/u.yaml"
+            errorMessage:
+              contains: "tags must include a u tag with the request URL"
           - contains:
               $ref: "@/tag/method.yaml"
+            errorMessage:
+              contains: "tags must include a method tag with the HTTP method"
     required:
       - tags

--- a/nips/nip-98/kind-27235/schema.yaml
+++ b/nips/nip-98/kind-27235/schema.yaml
@@ -1,0 +1,20 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind27235
+description: "HTTP authentication event defined by NIP-98"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 27235
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        allOf:
+          - contains:
+              $ref: "@/tag/u.yaml"
+          - contains:
+              $ref: "@/tag/method.yaml"
+    required:
+      - tags

--- a/nips/nip-98/tag/method/schema.yaml
+++ b/nips/nip-98/tag/method/schema.yaml
@@ -7,5 +7,5 @@ allOf:
     items:
       - const: "method"
       - type: string
-        enum: ["GET", "POST", "PUT", "PATCH", "DELETE"]
+        pattern: '^[A-Z]+$'
     additionalItems: false

--- a/nips/nip-98/tag/method/schema.yaml
+++ b/nips/nip-98/tag/method/schema.yaml
@@ -1,0 +1,11 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "method"
+      - type: string
+        enum: ["GET", "POST", "PUT", "PATCH", "DELETE"]
+    additionalItems: false

--- a/nips/nip-98/tag/payload/schema.yaml
+++ b/nips/nip-98/tag/payload/schema.yaml
@@ -1,0 +1,11 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "payload"
+      - type: string
+        pattern: '^[a-f0-9]{64}$'
+    additionalItems: false


### PR DESCRIPTION
## Summary

- Adds kind schemas, tag schemas, aliases, and valid/invalid samples for 7 NIPs that had open beads but no schemas
- 25 new kind schemas, 17 new tag schemas, 112 new files total
- All 245 tests pass (`pnpm build:test`)

| NIP | Description | Kinds | New Tags |
|-----|-------------|-------|----------|
| 29 | Relay-based Groups | 9000-9002, 9005, 9007-9009, 9021, 9022, 39000-39003 (13) | code |
| 37 | Draft Events | 31234, 10013 (2) | — |
| 60 | Cashu Wallet | 7374, 7375, 17375 (3) | — |
| 69 | P2P Orders | 38383 (1) | k, f, s, amt, fa, pm, premium, network, layer, expires_at, y, z |
| 71 | Video Events | 21, 22, 34235, 34236 (4) | — |
| 94 | File Metadata | 1063 (1) | url, m, ox |
| 98 | HTTP Auth | 27235 (1) | method, payload |

### Notes
- NIP-60 kind 7376 skipped (already exists in NIP-61)
- NIP-71 uses inline imeta validation (NIP-68 imeta restricts MIME to `image/*`, videos need `video/*`)
- NIP-69 `k` tag uses collision alias `@/tag/nip-69_k.yaml` (existing `@/tag/k.yaml` points to NIP-18)
- Addressable kinds (30000+) include `additionalProperties: true`

## Test plan

- [x] `pnpm build` exits 0
- [x] `pnpm test` — 245 tests pass (198 existing + 47 new)
- [x] All 25 new kind schemas appear in `dist/`
- [x] No `$id` in source YAML files
- [x] All schemas use JSON Schema draft-07

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive JSON Schema support across many NIPs (29, 37, 60, 69, 71, 94, 98) to validate numerous event kinds (group, trade, wallet/token, media, invites, etc.).
  * Added many tag-level validators (amt, expires_at, code, method, payload, url, imeta, layer, network, premium, s, y, z, k, f, fa, pm, ox, m, h, p, e) for stricter tag validation.
  * Added matching valid/invalid sample data for testing and documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->