### PR TITLE
Add 17 event kind schemas for published NIP coverage gaps

### DIFF
--- a/nips/nip-03/kind-1040/samples/invalid.wrong-kind.json
+++ b/nips/nip-03/kind-1040/samples/invalid.wrong-kind.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1,
+  "tags": [
+    ["e", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"],
+    ["k", "1"]
+  ],
+  "content": "AE9wZW5UaW1lc3RhbXBzAAJQcm9vZgA=",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-03/kind-1040/samples/valid.json
+++ b/nips/nip-03/kind-1040/samples/valid.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1040,
+  "tags": [
+    ["e", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"],
+    ["k", "1"]
+  ],
+  "content": "AE9wZW5UaW1lc3RhbXBzAAJQcm9vZgA=",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-03/kind-1040/schema.yaml
+++ b/nips/nip-03/kind-1040/schema.yaml
@@ -1,0 +1,34 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind1040
+description: NIP-03 OpenTimestamps attestation event
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 1040
+        errorMessage: "kind must equal 1040"
+      content:
+        type: string
+        minLength: 1
+        pattern: "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"
+        errorMessage:
+          pattern: "content must be valid Base64-encoded OpenTimestamps data"
+        description: "Base64-encoded OpenTimestamps .ots file data"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        allOf:
+          - contains:
+              $ref: "@/tag/e.yaml"
+            errorMessage:
+              contains: "tags must include an e tag referencing the target event"
+          - contains:
+              $ref: "@/tag/k.yaml"
+            errorMessage:
+              contains: "tags must include a k tag with the target event kind"
+    required:
+      - kind
+      - content
+      - tags

--- a/nips/nip-35/kind-2003/samples/invalid.wrong-kind.json
+++ b/nips/nip-35/kind-2003/samples/invalid.wrong-kind.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1,
+  "tags": [
+    ["title", "Test Torrent"],
+    ["x", "abc123hash"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-35/kind-2003/samples/valid.json
+++ b/nips/nip-35/kind-2003/samples/valid.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 2003,
+  "tags": [
+    ["title", "Test Torrent"],
+    ["x", "aabbccddee11223344556677aabbccddee112233"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-35/kind-2003/schema.yaml
+++ b/nips/nip-35/kind-2003/schema.yaml
@@ -1,0 +1,34 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind2003
+description: NIP-35 torrent metadata event
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 2003
+        errorMessage: "kind must equal 2003"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        allOf:
+          - contains:
+              $ref: "@/tag/title.yaml"
+            errorMessage:
+              contains: "tags must include a title tag"
+          - contains:
+              allOf:
+                - $ref: "@/tag.yaml"
+                - type: array
+                  minItems: 2
+                  items:
+                    - const: "x"
+                    - type: string
+                      pattern: "^[a-fA-F0-9]{40}$"
+                      description: "V1 BitTorrent info hash (SHA-1)"
+            errorMessage:
+              contains: "tags must include an x tag with a V1 BitTorrent info hash"
+    required:
+      - kind
+      - tags

--- a/nips/nip-35/kind-2004/samples/invalid.wrong-kind.json
+++ b/nips/nip-35/kind-2004/samples/invalid.wrong-kind.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1,
+  "tags": [
+    ["e", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"]
+  ],
+  "content": "Great torrent, thanks!",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-35/kind-2004/samples/valid.json
+++ b/nips/nip-35/kind-2004/samples/valid.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 2004,
+  "tags": [
+    ["e", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"]
+  ],
+  "content": "Great torrent, thanks!",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-35/kind-2004/schema.yaml
+++ b/nips/nip-35/kind-2004/schema.yaml
@@ -1,0 +1,21 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind2004
+description: NIP-35 torrent comment event
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 2004
+        errorMessage: "kind must equal 2004"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        contains:
+          $ref: "@/tag/e.yaml"
+        errorMessage:
+          contains: "tags must include an e tag referencing the torrent event"
+    required:
+      - kind
+      - tags

--- a/nips/nip-39/kind-10011/samples/invalid.wrong-kind.json
+++ b/nips/nip-39/kind-10011/samples/invalid.wrong-kind.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1,
+  "tags": [
+    ["i", "github:testuser", "abc123"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-39/kind-10011/samples/valid.json
+++ b/nips/nip-39/kind-10011/samples/valid.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 10011,
+  "tags": [
+    ["i", "github:testuser", "abc123"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-39/kind-10011/schema.yaml
+++ b/nips/nip-39/kind-10011/schema.yaml
@@ -1,0 +1,28 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind10011
+description: NIP-39 external identity claims event
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 10011
+        errorMessage: "kind must equal 10011"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        contains:
+          type: array
+          minItems: 3
+          items:
+            - const: "i"
+            - type: string
+              pattern: "^[a-z0-9._\\-/]+:.+"
+              description: "platform:identity pair"
+            - description: "Proof of identity ownership (string or object)"
+        errorMessage:
+          contains: "tags must include at least one i tag with a platform:identity claim and proof"
+    required:
+      - kind
+      - tags

--- a/nips/nip-54/kind-30818/samples/invalid.wrong-kind.json
+++ b/nips/nip-54/kind-30818/samples/invalid.wrong-kind.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1,
+  "tags": [
+    ["d", "test-article"]
+  ],
+  "content": "A wiki article",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-54/kind-30818/samples/valid.json
+++ b/nips/nip-54/kind-30818/samples/valid.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 30818,
+  "tags": [
+    ["d", "test-article"]
+  ],
+  "content": "A wiki article",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-54/kind-30818/schema.yaml
+++ b/nips/nip-54/kind-30818/schema.yaml
@@ -1,0 +1,27 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind30818
+description: NIP-54 wiki article event
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 30818
+        errorMessage: "kind must equal 30818"
+      content:
+        type: string
+        minLength: 1
+        errorMessage: "content must be a non-empty Djot markup string"
+        description: "Article content in Djot markup format"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        contains:
+          $ref: "@/tag/d.yaml"
+        errorMessage:
+          contains: "tags must include a d tag with the article identifier"
+    required:
+      - kind
+      - content
+      - tags

--- a/nips/nip-62/kind-62/samples/invalid.wrong-kind.json
+++ b/nips/nip-62/kind-62/samples/invalid.wrong-kind.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1,
+  "tags": [
+    ["relay", "wss://relay.example.com"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-62/kind-62/samples/valid.json
+++ b/nips/nip-62/kind-62/samples/valid.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 62,
+  "tags": [
+    ["relay", "wss://relay.example.com"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-62/kind-62/schema.yaml
+++ b/nips/nip-62/kind-62/schema.yaml
@@ -1,0 +1,21 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind62
+description: NIP-62 request to vanish event
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 62
+        errorMessage: "kind must equal 62"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        contains:
+          $ref: "@/tag/relay.yaml"
+        errorMessage:
+          contains: "tags must include at least one relay tag"
+    required:
+      - kind
+      - tags

--- a/nips/nip-64/kind-64/samples/invalid.wrong-kind.json
+++ b/nips/nip-64/kind-64/samples/invalid.wrong-kind.json
@@ -1,0 +1,9 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1,
+  "tags": [],
+  "content": "1. e4 e5 *",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-64/kind-64/samples/valid.json
+++ b/nips/nip-64/kind-64/samples/valid.json
@@ -1,0 +1,9 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 64,
+  "tags": [],
+  "content": "1. e4 e5 *",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-64/kind-64/schema.yaml
+++ b/nips/nip-64/kind-64/schema.yaml
@@ -1,0 +1,18 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind64
+description: NIP-64 chess game in Portable Game Notation (PGN) format
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 64
+        errorMessage: "kind must equal 64"
+      content:
+        type: string
+        minLength: 1
+        errorMessage: "content must be a non-empty PGN string"
+        description: "PGN-database string representing a chess game"
+    required:
+      - kind
+      - content

--- a/nips/nip-66/kind-10166/samples/invalid.wrong-kind.json
+++ b/nips/nip-66/kind-10166/samples/invalid.wrong-kind.json
@@ -1,0 +1,9 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1,
+  "tags": [],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-66/kind-10166/samples/valid.json
+++ b/nips/nip-66/kind-10166/samples/valid.json
@@ -1,0 +1,9 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 10166,
+  "tags": [],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-66/kind-10166/schema.yaml
+++ b/nips/nip-66/kind-10166/schema.yaml
@@ -1,0 +1,12 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind10166
+description: NIP-66 relay monitor announcement event
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 10166
+        errorMessage: "kind must equal 10166"
+    required:
+      - kind

--- a/nips/nip-66/kind-30166/samples/invalid.wrong-kind.json
+++ b/nips/nip-66/kind-30166/samples/invalid.wrong-kind.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1,
+  "tags": [
+    ["d", "wss://relay.example.com"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-66/kind-30166/samples/valid.json
+++ b/nips/nip-66/kind-30166/samples/valid.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 30166,
+  "tags": [
+    ["d", "wss://relay.example.com"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-66/kind-30166/schema.yaml
+++ b/nips/nip-66/kind-30166/schema.yaml
@@ -1,0 +1,21 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind30166
+description: NIP-66 relay discovery event
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 30166
+        errorMessage: "kind must equal 30166"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        contains:
+          $ref: "@/tag/d.yaml"
+        errorMessage:
+          contains: "tags must include a d tag with the relay URL"
+    required:
+      - kind
+      - tags

--- a/nips/nip-72/kind-34550/samples/invalid.wrong-kind.json
+++ b/nips/nip-72/kind-34550/samples/invalid.wrong-kind.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1,
+  "tags": [
+    ["d", "test-community"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-72/kind-34550/samples/valid.json
+++ b/nips/nip-72/kind-34550/samples/valid.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 34550,
+  "tags": [
+    ["d", "test-community"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-72/kind-34550/schema.yaml
+++ b/nips/nip-72/kind-34550/schema.yaml
@@ -1,0 +1,21 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind34550
+description: NIP-72 community definition event
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 34550
+        errorMessage: "kind must equal 34550"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        contains:
+          $ref: "@/tag/d.yaml"
+        errorMessage:
+          contains: "tags must include a d tag with the community identifier"
+    required:
+      - kind
+      - tags

--- a/nips/nip-72/kind-4550/samples/invalid.wrong-kind.json
+++ b/nips/nip-72/kind-4550/samples/invalid.wrong-kind.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1,
+  "tags": [
+    ["a", "34550:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:test"],
+    ["p", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-72/kind-4550/samples/valid.json
+++ b/nips/nip-72/kind-4550/samples/valid.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 4550,
+  "tags": [
+    ["a", "34550:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:test"],
+    ["p", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-72/kind-4550/schema.yaml
+++ b/nips/nip-72/kind-4550/schema.yaml
@@ -1,0 +1,26 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind4550
+description: NIP-72 community post approval event
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 4550
+        errorMessage: "kind must equal 4550"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        allOf:
+          - contains:
+              $ref: "@/tag/a.yaml"
+            errorMessage:
+              contains: "tags must include an a tag referencing the community"
+          - contains:
+              $ref: "@/tag/p.yaml"
+            errorMessage:
+              contains: "tags must include a p tag with the post author pubkey"
+    required:
+      - kind
+      - tags

--- a/nips/nip-75/kind-9041/samples/invalid.wrong-kind.json
+++ b/nips/nip-75/kind-9041/samples/invalid.wrong-kind.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1,
+  "tags": [
+    ["amount", "1000000"],
+    ["relays", "wss://relay.example.com"]
+  ],
+  "content": "Help fund my project",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-75/kind-9041/samples/valid.json
+++ b/nips/nip-75/kind-9041/samples/valid.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 9041,
+  "tags": [
+    ["amount", "1000000"],
+    ["relays", "wss://relay.example.com"]
+  ],
+  "content": "Help fund my project",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-75/kind-9041/schema.yaml
+++ b/nips/nip-75/kind-9041/schema.yaml
@@ -1,0 +1,26 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind9041
+description: NIP-75 zap goal event
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 9041
+        errorMessage: "kind must equal 9041"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        allOf:
+          - contains:
+              $ref: "@/tag/amount.yaml"
+            errorMessage:
+              contains: "tags must include an amount tag with the target in millisats"
+          - contains:
+              $ref: "@/tag/relays.yaml"
+            errorMessage:
+              contains: "tags must include a relays tag with relay URLs for zap tallying"
+    required:
+      - kind
+      - tags

--- a/nips/nip-90/kind-5300/samples/invalid.wrong-kind.json
+++ b/nips/nip-90/kind-5300/samples/invalid.wrong-kind.json
@@ -1,0 +1,9 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1,
+  "tags": [],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-90/kind-5300/samples/valid.json
+++ b/nips/nip-90/kind-5300/samples/valid.json
@@ -1,0 +1,9 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 5300,
+  "tags": [],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-90/kind-5300/schema.yaml
+++ b/nips/nip-90/kind-5300/schema.yaml
@@ -1,0 +1,12 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind5300
+description: NIP-90 DVM content discovery job request
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 5300
+        errorMessage: "kind must equal 5300"
+    required:
+      - kind

--- a/nips/nip-90/kind-5301/samples/invalid.wrong-kind.json
+++ b/nips/nip-90/kind-5301/samples/invalid.wrong-kind.json
@@ -1,0 +1,9 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1,
+  "tags": [],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-90/kind-5301/samples/valid.json
+++ b/nips/nip-90/kind-5301/samples/valid.json
@@ -1,0 +1,9 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 5301,
+  "tags": [],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-90/kind-5301/schema.yaml
+++ b/nips/nip-90/kind-5301/schema.yaml
@@ -1,0 +1,12 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind5301
+description: NIP-90 DVM user discovery job request
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 5301
+        errorMessage: "kind must equal 5301"
+    required:
+      - kind

--- a/nips/nip-90/kind-6300/samples/invalid.missing-e-tag.json
+++ b/nips/nip-90/kind-6300/samples/invalid.missing-e-tag.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 6300,
+  "tags": [
+    ["p", "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"],
+    ["request", "{\"id\":\"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\"}"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-90/kind-6300/samples/valid.json
+++ b/nips/nip-90/kind-6300/samples/valid.json
@@ -1,0 +1,13 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 6300,
+  "tags": [
+    ["e", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"],
+    ["p", "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"],
+    ["request", "{\"id\":\"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\"}"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-90/kind-6300/schema.yaml
+++ b/nips/nip-90/kind-6300/schema.yaml
@@ -1,0 +1,33 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind6300
+description: NIP-90 DVM content discovery job result
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 6300
+        errorMessage: "kind must equal 6300"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 3
+        errorMessage:
+          minItems: "tags must contain at least three tags (e, p, request)"
+        allOf:
+          - contains:
+              $ref: "@/tag/e.yaml"
+            errorMessage:
+              contains: "tags must include an e tag referencing the job request event"
+          - contains:
+              $ref: "@/tag/p.yaml"
+            errorMessage:
+              contains: "tags must include a p tag with the customer's pubkey"
+          - contains:
+              $ref: "@/tag/request.yaml"
+            errorMessage:
+              contains: "tags must include a request tag with the original job request JSON"
+    required:
+      - kind
+      - tags

--- a/nips/nip-90/kind-6301/samples/invalid.missing-e-tag.json
+++ b/nips/nip-90/kind-6301/samples/invalid.missing-e-tag.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 6301,
+  "tags": [
+    ["p", "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"],
+    ["request", "{\"id\":\"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\"}"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-90/kind-6301/samples/valid.json
+++ b/nips/nip-90/kind-6301/samples/valid.json
@@ -1,0 +1,13 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 6301,
+  "tags": [
+    ["e", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"],
+    ["p", "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"],
+    ["request", "{\"id\":\"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\"}"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-90/kind-6301/schema.yaml
+++ b/nips/nip-90/kind-6301/schema.yaml
@@ -1,0 +1,33 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind6301
+description: NIP-90 DVM user discovery job result
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 6301
+        errorMessage: "kind must equal 6301"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 3
+        errorMessage:
+          minItems: "tags must contain at least three tags (e, p, request)"
+        allOf:
+          - contains:
+              $ref: "@/tag/e.yaml"
+            errorMessage:
+              contains: "tags must include an e tag referencing the job request event"
+          - contains:
+              $ref: "@/tag/p.yaml"
+            errorMessage:
+              contains: "tags must include a p tag with the customer's pubkey"
+          - contains:
+              $ref: "@/tag/request.yaml"
+            errorMessage:
+              contains: "tags must include a request tag with the original job request JSON"
+    required:
+      - kind
+      - tags

--- a/nips/nip-96/kind-10096/samples/invalid.wrong-kind.json
+++ b/nips/nip-96/kind-10096/samples/invalid.wrong-kind.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1,
+  "tags": [
+    ["server", "https://files.example.com"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-96/kind-10096/samples/valid.json
+++ b/nips/nip-96/kind-10096/samples/valid.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 10096,
+  "tags": [
+    ["server", "https://files.example.com"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-96/kind-10096/schema.yaml
+++ b/nips/nip-96/kind-10096/schema.yaml
@@ -1,0 +1,23 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind10096
+description: NIP-96 file server preference list event
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 10096
+        errorMessage: "kind must equal 10096"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag/server.yaml"
+        additionalItems: false
+        minItems: 1
+        errorMessage:
+          type: "tags must be an array of server tags"
+          minItems: "tags must contain at least one server tag"
+          additionalItems: "file server lists must only include server tags"
+    required:
+      - kind
+      - tags


### PR DESCRIPTION
## Summary

Addresses #89 by adding schemas for **17 verified event kinds** from published NIPs that were identified as coverage gaps.

### New schemas (10 new NIPs, 4 existing NIPs extended)

| NIP | Kind(s) | Description |
|-----|---------|-------------|
| NIP-03 | 1040 | OpenTimestamps attestation |
| NIP-35 | 2003, 2004 | Torrent metadata, torrent comment |
| NIP-39 | 10011 | External identity claims |
| NIP-54 | 30818 | Wiki article (Djot) |
| NIP-62 | 62 | Request to vanish |
| NIP-64 | 64 | Chess game (PGN) |
| NIP-66 | 10166, 30166 | Relay monitor announcement, relay discovery |
| NIP-72 | 4550, 34550 | Community post approval, community definition |
| NIP-75 | 9041 | Zap goal |
| NIP-90 | 5300, 5301, 6300, 6301 | DVM content/user discovery request/result |
| NIP-96 | 10096 | File server preference list |

### Rejected kinds from #89 (13)

Each kind from the issue was cross-referenced against the actual NIP specs in [nostr-protocol/nips](https://github.com/nostr-protocol/nips):

- **Fabricated (10):** 10081/10086/10087/10088/10089 (not in NIP-51), 9733 (not in NIP-57), 30064/30065/30066/30067/30068 (not in NIP-64)
- **Misattributed (1):** kind 30 belongs to NKBIP-03, not NIP-64
- **Deprecated (2):** kind 1622 (NIP-34, replaced by NIP-22 kind 1111), kind 30001 (NIP-51, replaced by specific list kinds)

### Notes

- NIP-39 `i` tags use a different format than NIP-73's `i` tags (proof string vs URL), so kind 10011 uses an inline tag definition rather than the `@/tag/external-content-i.yaml` alias
- NIP-90 DVM response kinds (6300, 6301) follow the existing kind-6000 pattern requiring `e`, `p`, and `request` tags
- All schemas include valid + invalid samples and pass the full test suite (1699/1699)

## Test plan

- [x] `pnpm build` succeeds
- [x] `pnpm test` passes (1699/1699 tests, 0 failures)
- [x] Each schema has `samples/` with valid and invalid fixtures
- [ ] Review schema tag constraints match NIP spec requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JSON Schemas and matching valid/invalid sample events for 11 NIPs (03, 35, 39, 54, 62, 64, 66, 72, 75, 90, 96).
  * Schemas enforce required fields, tag constraints, and content formats (with custom error messages).
  * Included representative valid and invalid sample payloads to aid validation, testing, and documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->