### PR TITLE
Add schemas for kinds 1222, 1244, 24242, 30382

### DIFF
--- a/nips/nip-85/kind-30382/samples/invalid.missing-d-tag.json
+++ b/nips/nip-85/kind-30382/samples/invalid.missing-d-tag.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 30382,
+  "tags": [
+    ["rank", "89"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-85/kind-30382/samples/invalid.non-empty-content.json
+++ b/nips/nip-85/kind-30382/samples/invalid.non-empty-content.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 30382,
+  "tags": [
+    ["d", "e88a691e98d9987c964521dff60025f60700378a4879180dcbbb4a5027850411"]
+  ],
+  "content": "this should be empty",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-85/kind-30382/samples/invalid.wrong-kind.json
+++ b/nips/nip-85/kind-30382/samples/invalid.wrong-kind.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1,
+  "tags": [
+    ["d", "e88a691e98d9987c964521dff60025f60700378a4879180dcbbb4a5027850411"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-85/kind-30382/samples/valid.json
+++ b/nips/nip-85/kind-30382/samples/valid.json
@@ -1,0 +1,14 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 30382,
+  "tags": [
+    ["d", "e88a691e98d9987c964521dff60025f60700378a4879180dcbbb4a5027850411"],
+    ["rank", "89"],
+    ["followers", "1500"],
+    ["p", "e88a691e98d9987c964521dff60025f60700378a4879180dcbbb4a5027850411"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-85/kind-30382/samples/valid.minimal.json
+++ b/nips/nip-85/kind-30382/samples/valid.minimal.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 30382,
+  "tags": [
+    ["d", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-85/kind-30382/schema.yaml
+++ b/nips/nip-85/kind-30382/schema.yaml
@@ -1,0 +1,29 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind30382
+description: "NIP-85 Trusted Assertion (user as subject)"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 30382
+        errorMessage: "kind must equal 30382"
+      content:
+        type: string
+        maxLength: 0
+        description: "Content must be an empty string"
+        errorMessage: "content must be an empty string"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/d.yaml"
+            errorMessage:
+              contains: "tags must include a d tag with the target user pubkey"
+    required:
+      - kind
+      - content
+      - tags

--- a/nips/nip-A0/kind-1222/samples/invalid.missing-content-url.json
+++ b/nips/nip-A0/kind-1222/samples/invalid.missing-content-url.json
@@ -1,0 +1,9 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1222,
+  "tags": [],
+  "content": "this is not a URL",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-A0/kind-1222/samples/invalid.wrong-kind.json
+++ b/nips/nip-A0/kind-1222/samples/invalid.wrong-kind.json
@@ -1,0 +1,9 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1,
+  "tags": [],
+  "content": "https://blossom.example.com/abc123.mp4",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-A0/kind-1222/samples/valid.json
+++ b/nips/nip-A0/kind-1222/samples/valid.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1222,
+  "tags": [
+    ["imeta", "url https://blossom.example.com/abc123.mp4", "waveform 0 7 35 8 100 49 8 4 16", "duration 8"]
+  ],
+  "content": "https://blossom.example.com/abc123.mp4",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-A0/kind-1222/schema.yaml
+++ b/nips/nip-A0/kind-1222/schema.yaml
@@ -1,0 +1,18 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind1222
+description: "NIP-A0 Voice Message"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 1222
+        errorMessage: "kind must equal 1222"
+      content:
+        type: string
+        pattern: "^https?://\\S+$"
+        description: "URL pointing directly to an audio file"
+        errorMessage: "content must be a URL to an audio file"
+    required:
+      - kind
+      - content

--- a/nips/nip-A0/kind-1244/samples/invalid.wrong-kind.json
+++ b/nips/nip-A0/kind-1244/samples/invalid.wrong-kind.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1,
+  "tags": [
+    ["e", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["p", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"]
+  ],
+  "content": "https://blossom.example.com/reply456.mp4",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-A0/kind-1244/samples/valid.json
+++ b/nips/nip-A0/kind-1244/samples/valid.json
@@ -1,0 +1,15 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1244,
+  "tags": [
+    ["e", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["p", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"],
+    ["K", "1222"],
+    ["k", "1222"],
+    ["imeta", "url https://blossom.example.com/reply456.mp4", "duration 5"]
+  ],
+  "content": "https://blossom.example.com/reply456.mp4",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-A0/kind-1244/schema.yaml
+++ b/nips/nip-A0/kind-1244/schema.yaml
@@ -1,0 +1,18 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind1244
+description: "NIP-A0 Voice Message Reply (NIP-22 comment threading)"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 1244
+        errorMessage: "kind must equal 1244"
+      content:
+        type: string
+        pattern: "^https?://\\S+$"
+        description: "URL pointing directly to an audio file"
+        errorMessage: "content must be a URL to an audio file"
+    required:
+      - kind
+      - content

--- a/nips/nipless/kind-24242/samples/invalid.missing-expiration.json
+++ b/nips/nipless/kind-24242/samples/invalid.missing-expiration.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 24242,
+  "tags": [
+    ["t", "upload"]
+  ],
+  "content": "Upload Blob",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nipless/kind-24242/samples/invalid.missing-t-tag.json
+++ b/nips/nipless/kind-24242/samples/invalid.missing-t-tag.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 24242,
+  "tags": [
+    ["expiration", "1708858680"]
+  ],
+  "content": "Upload Blob",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nipless/kind-24242/samples/invalid.wrong-kind.json
+++ b/nips/nipless/kind-24242/samples/invalid.wrong-kind.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1,
+  "tags": [
+    ["t", "upload"],
+    ["expiration", "1708858680"]
+  ],
+  "content": "Upload Blob",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nipless/kind-24242/samples/valid.json
+++ b/nips/nipless/kind-24242/samples/valid.json
@@ -1,0 +1,14 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 24242,
+  "tags": [
+    ["t", "upload"],
+    ["expiration", "1708858680"],
+    ["x", "b1674191a88ec5cdd733e4240a81803105dc412d6c6708d53ab94fc248f4f553"],
+    ["server", "cdn.example.com"]
+  ],
+  "content": "Upload Blob",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nipless/kind-24242/samples/valid.list.json
+++ b/nips/nipless/kind-24242/samples/valid.list.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 24242,
+  "tags": [
+    ["t", "list"],
+    ["expiration", "1708858680"]
+  ],
+  "content": "List Blobs",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nipless/kind-24242/schema.yaml
+++ b/nips/nipless/kind-24242/schema.yaml
@@ -1,0 +1,35 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind24242
+description: "Blossom Authorization Event (BUD-11)"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 24242
+        errorMessage: "kind must equal 24242"
+      content:
+        type: string
+        description: "Human-readable description of the intended action"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 2
+        allOf:
+          - contains:
+              type: array
+              items:
+                - const: "t"
+                - type: string
+                  enum: ["get", "upload", "list", "delete", "media"]
+            errorMessage:
+              contains: "tags must include a t tag with action verb (get, upload, list, delete, or media)"
+          - contains:
+              $ref: "@/tag/expiration.yaml"
+            errorMessage:
+              contains: "tags must include an expiration tag"
+    required:
+      - kind
+      - content
+      - tags

--- a/nips/nipless/kind-24242/schema.yaml
+++ b/nips/nipless/kind-24242/schema.yaml
@@ -19,6 +19,7 @@ allOf:
         allOf:
           - contains:
               type: array
+              minItems: 2
               items:
                 - const: "t"
                 - type: string


### PR DESCRIPTION
## Summary

- **kind 1222** (NIP-A0): Voice message — content is audio URL, optional `imeta` tag with waveform/duration
- **kind 1244** (NIP-A0): Voice message reply — same as 1222 with NIP-22 comment threading tags
- **kind 24242** (Blossom BUD-01): Authorization event — requires `t` tag (get/upload/list/delete/media) + `expiration` tag
- **kind 30382** (NIP-85): Trusted assertion (user as subject) — replaceable, `d` tag = target pubkey, content must be empty

Each schema includes valid + invalid samples (19 files total). All 1746 tests pass.

Motivated by coverage gap analysis for [nostria integration](https://github.com/nostrability/schemata/issues/91).

## Test plan

- [x] `pnpm build` compiles all 4 new schemas
- [x] `pnpm test` — 1746 tests pass (sample-coverage, error-messages, structural-lint, samples)
- [ ] Verify schemas match NIP specs: [NIP-A0](https://github.com/nostr-protocol/nips/blob/master/A0.md), [NIP-85](https://github.com/nostr-protocol/nips/blob/master/85.md), [BUD-01](https://github.com/hzrd149/blossom/blob/master/buds/01.md)

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added JSON validation schemas and accompanying sample events for NIP-85 (trusted assertions), NIP-A0 (media/voice messages and replies) and Blossom authorization events. Includes both valid and invalid examples illustrating constraints (required tags, empty vs non-empty content, exact kind values, URL-formatted content, expiration requirements) to aid validation and testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->