### PR TITLE
Add 21 event kind schemas across 9 NIPs + audit fixes for 15 specs

### DIFF
--- a/@/tag/accessed_on.yaml
+++ b/@/tag/accessed_on.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nkbip-03/tag/accessed_on/schema.yaml"

--- a/@/tag/author.yaml
+++ b/@/tag/author.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nkbip-03/tag/author/schema.yaml"

--- a/@/tag/branch-name.yaml
+++ b/@/tag/branch-name.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-34/tag/branch-name/schema.yaml"

--- a/@/tag/c.yaml
+++ b/@/tag/c.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-34/tag/c/schema.yaml"

--- a/@/tag/chapter_title.yaml
+++ b/@/tag/chapter_title.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nkbip-03/tag/chapter_title/schema.yaml"

--- a/@/tag/claim.yaml
+++ b/@/tag/claim.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-43/tag/claim/schema.yaml"

--- a/@/tag/doi.yaml
+++ b/@/tag/doi.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nkbip-03/tag/doi/schema.yaml"

--- a/@/tag/editor.yaml
+++ b/@/tag/editor.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nkbip-03/tag/editor/schema.yaml"

--- a/@/tag/llm.yaml
+++ b/@/tag/llm.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nkbip-03/tag/llm/schema.yaml"

--- a/@/tag/member.yaml
+++ b/@/tag/member.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-43/tag/member/schema.yaml"

--- a/@/tag/merge-base.yaml
+++ b/@/tag/merge-base.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-34/tag/merge-base/schema.yaml"

--- a/@/tag/mls_proposals.yaml
+++ b/@/tag/mls_proposals.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "mips/mip-00/tag/mls_proposals/schema.yaml"

--- a/@/tag/modules.yaml
+++ b/@/tag/modules.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-87/tag/modules/schema.yaml"

--- a/@/tag/n.yaml
+++ b/@/tag/n.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-87/tag/n/schema.yaml"

--- a/@/tag/nuts.yaml
+++ b/@/tag/nuts.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-87/tag/nuts/schema.yaml"

--- a/@/tag/page_range.yaml
+++ b/@/tag/page_range.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nkbip-03/tag/page_range/schema.yaml"

--- a/@/tag/path.yaml
+++ b/@/tag/path.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-5A/tag/path/schema.yaml"

--- a/@/tag/protected.yaml
+++ b/@/tag/protected.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-43/tag/protected/schema.yaml"

--- a/@/tag/published_by.yaml
+++ b/@/tag/published_by.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nkbip-03/tag/published_by/schema.yaml"

--- a/@/tag/published_in.yaml
+++ b/@/tag/published_in.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nkbip-03/tag/published_in/schema.yaml"

--- a/@/tag/published_on.yaml
+++ b/@/tag/published_on.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nkbip-03/tag/published_on/schema.yaml"

--- a/@/tag/source.yaml
+++ b/@/tag/source.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-5A/tag/source/schema.yaml"

--- a/@/tag/version.yaml
+++ b/@/tag/version.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nkbip-03/tag/version/schema.yaml"

--- a/mips/mip-00/kind-443/samples/valid.json
+++ b/mips/mip-00/kind-443/samples/valid.json
@@ -7,6 +7,7 @@
     ["mls_protocol_version", "1.0"],
     ["mls_ciphersuite", "0x0001"],
     ["mls_extensions", "0xf2ee", "0x000a"],
+    ["mls_proposals", "0x000a"],
     ["relays", "wss://relay.example.com", "wss://relay2.example.com"],
     ["encoding", "base64"],
     ["i", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"]

--- a/mips/mip-00/kind-443/schema.yaml
+++ b/mips/mip-00/kind-443/schema.yaml
@@ -20,6 +20,8 @@ allOf:
         items:
           $ref: "@/tag.yaml"
         minItems: 7
+        errorMessage:
+          minItems: "tags must include at least 7 required MIP-00 tags"
         allOf:
           - contains:
               $ref: "@/tag/mls_protocol_version.yaml"

--- a/mips/mip-00/kind-443/schema.yaml
+++ b/mips/mip-00/kind-443/schema.yaml
@@ -19,7 +19,7 @@ allOf:
         type: array
         items:
           $ref: "@/tag.yaml"
-        minItems: 6
+        minItems: 7
         allOf:
           - contains:
               $ref: "@/tag/mls_protocol_version.yaml"
@@ -33,6 +33,10 @@ allOf:
               $ref: "@/tag/mls_extensions.yaml"
             errorMessage:
               contains: "tags must include an mls_extensions tag"
+          - contains:
+              $ref: "@/tag/mls_proposals.yaml"
+            errorMessage:
+              contains: "tags must include an mls_proposals tag"
           - contains:
               $ref: "@/tag/relays.yaml"
             errorMessage:

--- a/mips/mip-00/tag/mls_proposals/schema.yaml
+++ b/mips/mip-00/tag/mls_proposals/schema.yaml
@@ -1,0 +1,20 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+title: MLS Proposals
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    uniqueItems: true
+    items:
+      - const: "mls_proposals"
+      - type: string
+        pattern: "^0x[0-9a-f]{4}$"
+        description: "MLS proposal type identifier"
+    additionalItems:
+      type: string
+      pattern: "^0x[0-9a-f]{4}$"
+    allOf:
+      - contains:
+          const: "0x000a"
+        errorMessage:
+          contains: "mls_proposals must include 0x000a (self_remove)"

--- a/nips/nip-34/kind-1618/samples/invalid.missing-subject.json
+++ b/nips/nip-34/kind-1618/samples/invalid.missing-subject.json
@@ -1,0 +1,14 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1618,
+  "tags": [
+    ["a", "30617:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:my-repo"],
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["c", "abcdef1234567890abcdef1234567890abcdef12"],
+    ["clone", "https://github.com/example/repo.git"]
+  ],
+  "content": "This PR fixes a small typo.",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-34/kind-1618/samples/valid.json
+++ b/nips/nip-34/kind-1618/samples/valid.json
@@ -1,0 +1,15 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1618,
+  "tags": [
+    ["a", "30617:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:my-repo"],
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["subject", "Fix typo in README"],
+    ["c", "abcdef1234567890abcdef1234567890abcdef12"],
+    ["clone", "https://github.com/example/repo.git"]
+  ],
+  "content": "This PR fixes a small typo in the README file.",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-34/kind-1618/schema.yaml
+++ b/nips/nip-34/kind-1618/schema.yaml
@@ -1,0 +1,55 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind1618
+description: NIP-34 pull request event
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 1618
+        errorMessage: "kind must equal 1618"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/a.yaml"
+            errorMessage:
+              contains: "tags must include an a tag referencing the target repository"
+          - contains:
+              $ref: "@/tag/p.yaml"
+            errorMessage:
+              contains: "tags must include a p tag for the repository owner"
+          - contains:
+              $ref: "@/tag/subject.yaml"
+            errorMessage:
+              contains: "tags must include a subject tag with the PR title"
+          - contains:
+              $ref: "@/tag/c.yaml"
+            errorMessage:
+              contains: "tags must include a c tag with the tip commit hash"
+          - contains:
+              $ref: "@/tag/clone.yaml"
+            errorMessage:
+              contains: "tags must include a clone tag with at least one clone URL"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "merge-base"
+            then:
+              contains:
+                $ref: "@/tag/merge-base.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "branch-name"
+            then:
+              contains:
+                $ref: "@/tag/branch-name.yaml"
+    required:
+      - kind
+      - tags

--- a/nips/nip-34/kind-1619/samples/invalid.missing-clone.json
+++ b/nips/nip-34/kind-1619/samples/invalid.missing-clone.json
@@ -1,0 +1,15 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1619,
+  "tags": [
+    ["a", "30617:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:my-repo"],
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["E", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"],
+    ["P", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"],
+    ["c", "def4567890abcdef1234567890abcdef12345678"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-34/kind-1619/samples/valid.json
+++ b/nips/nip-34/kind-1619/samples/valid.json
@@ -1,0 +1,16 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1619,
+  "tags": [
+    ["a", "30617:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:my-repo"],
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["E", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"],
+    ["P", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"],
+    ["c", "def4567890abcdef1234567890abcdef12345678"],
+    ["clone", "https://github.com/example/repo.git"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-34/kind-1619/schema.yaml
+++ b/nips/nip-34/kind-1619/schema.yaml
@@ -1,0 +1,66 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind1619
+description: NIP-34 pull request update event
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 1619
+        errorMessage: "kind must equal 1619"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/a.yaml"
+            errorMessage:
+              contains: "tags must include an a tag referencing the target repository"
+          - contains:
+              $ref: "@/tag/p.yaml"
+            errorMessage:
+              contains: "tags must include a p tag for the repository owner"
+          - contains:
+              $ref: "@/tag/c.yaml"
+            errorMessage:
+              contains: "tags must include a c tag with the updated tip commit hash"
+          - contains:
+              $ref: "@/tag/clone.yaml"
+            errorMessage:
+              contains: "tags must include a clone tag with at least one clone URL"
+          # NIP-22 uppercase tags for threading back to the PR event
+          - contains:
+              allOf:
+                - $ref: "@/tag.yaml"
+                - type: array
+                  minItems: 2
+                  items:
+                    - const: "E"
+                    - type: string
+                      pattern: '^[a-f0-9]{64}$'
+            errorMessage:
+              contains: "tags must include an E tag referencing the pull request event"
+          - contains:
+              allOf:
+                - $ref: "@/tag.yaml"
+                - type: array
+                  minItems: 2
+                  items:
+                    - const: "P"
+                    - type: string
+                      pattern: '^[a-f0-9]{64}$'
+            errorMessage:
+              contains: "tags must include a P tag referencing the pull request author"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "merge-base"
+            then:
+              contains:
+                $ref: "@/tag/merge-base.yaml"
+    required:
+      - kind
+      - tags

--- a/nips/nip-34/tag/branch-name/schema.yaml
+++ b/nips/nip-34/tag/branch-name/schema.yaml
@@ -5,10 +5,10 @@ allOf:
     minItems: 2
     maxItems: 2
     items:
-      - const: "layer"
+      - const: "branch-name"
       - type: string
         minLength: 1
-        description: "Payment layer (e.g. onchain, lightning, liquid)"
+        description: "Recommended branch name for the pull request"
     additionalItems: false
     errorMessage:
-      minItems: "layer tag must have at least 2 elements"
+      minItems: "branch-name tag must have at least 2 elements"

--- a/nips/nip-34/tag/c/schema.yaml
+++ b/nips/nip-34/tag/c/schema.yaml
@@ -5,10 +5,10 @@ allOf:
     minItems: 2
     maxItems: 2
     items:
-      - const: "layer"
+      - const: "c"
       - type: string
-        minLength: 1
-        description: "Payment layer (e.g. onchain, lightning, liquid)"
+        pattern: '^[a-f0-9]{40}$'
+        description: "Git commit hash (40 hex chars)"
     additionalItems: false
     errorMessage:
-      minItems: "layer tag must have at least 2 elements"
+      minItems: "c tag must have at least 2 elements"

--- a/nips/nip-34/tag/merge-base/schema.yaml
+++ b/nips/nip-34/tag/merge-base/schema.yaml
@@ -5,10 +5,10 @@ allOf:
     minItems: 2
     maxItems: 2
     items:
-      - const: "layer"
+      - const: "merge-base"
       - type: string
-        minLength: 1
-        description: "Payment layer (e.g. onchain, lightning, liquid)"
+        pattern: '^[a-f0-9]{40}$'
+        description: "Most recent common ancestor commit hash"
     additionalItems: false
     errorMessage:
-      minItems: "layer tag must have at least 2 elements"
+      minItems: "merge-base tag must have at least 2 elements"

--- a/nips/nip-43/kind-13534/samples/invalid.missing-member.json
+++ b/nips/nip-43/kind-13534/samples/invalid.missing-member.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 13534,
+  "tags": [
+    ["-"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-43/kind-13534/samples/valid.json
+++ b/nips/nip-43/kind-13534/samples/valid.json
@@ -1,0 +1,13 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 13534,
+  "tags": [
+    ["-"],
+    ["member", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["member", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-43/kind-13534/schema.yaml
+++ b/nips/nip-43/kind-13534/schema.yaml
@@ -1,0 +1,27 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind13534
+description: "NIP-43 Membership List event (relay access management)"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 13534
+        errorMessage: "kind must equal 13534"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/protected.yaml"
+            errorMessage:
+              contains: "tags must include a protected event tag ([\"-\"])"
+          - contains:
+              $ref: "@/tag/member.yaml"
+            errorMessage:
+              contains: "tags must include at least one member tag with a hex pubkey"
+    required:
+      - kind
+      - tags

--- a/nips/nip-43/kind-28934/samples/invalid.missing-claim.json
+++ b/nips/nip-43/kind-28934/samples/invalid.missing-claim.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 28934,
+  "tags": [
+    ["-"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-43/kind-28934/samples/valid.json
+++ b/nips/nip-43/kind-28934/samples/valid.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 28934,
+  "tags": [
+    ["-"],
+    ["claim", "abc123invite"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-43/kind-28934/schema.yaml
+++ b/nips/nip-43/kind-28934/schema.yaml
@@ -1,0 +1,27 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind28934
+description: "NIP-43 Join Request event (relay access management)"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 28934
+        errorMessage: "kind must equal 28934"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/protected.yaml"
+            errorMessage:
+              contains: "tags must include a protected event tag ([\"-\"])"
+          - contains:
+              $ref: "@/tag/claim.yaml"
+            errorMessage:
+              contains: "tags must include a claim tag with an invite code"
+    required:
+      - kind
+      - tags

--- a/nips/nip-43/kind-28935/samples/invalid.missing-protected.json
+++ b/nips/nip-43/kind-28935/samples/invalid.missing-protected.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 28935,
+  "tags": [
+    ["claim", "generated-invite-code-xyz"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-43/kind-28935/samples/valid.json
+++ b/nips/nip-43/kind-28935/samples/valid.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 28935,
+  "tags": [
+    ["-"],
+    ["claim", "generated-invite-code-xyz"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-43/kind-28935/schema.yaml
+++ b/nips/nip-43/kind-28935/schema.yaml
@@ -1,0 +1,27 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind28935
+description: "NIP-43 Invite Request response event (relay access management)"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 28935
+        errorMessage: "kind must equal 28935"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/protected.yaml"
+            errorMessage:
+              contains: "tags must include a protected event tag ([\"-\"])"
+          - contains:
+              $ref: "@/tag/claim.yaml"
+            errorMessage:
+              contains: "tags must include a claim tag with a generated invite code"
+    required:
+      - kind
+      - tags

--- a/nips/nip-43/kind-28936/samples/invalid.wrong-kind.json
+++ b/nips/nip-43/kind-28936/samples/invalid.wrong-kind.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 28937,
+  "tags": [
+    ["-"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-43/kind-28936/samples/valid.json
+++ b/nips/nip-43/kind-28936/samples/valid.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 28936,
+  "tags": [
+    ["-"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-43/kind-28936/schema.yaml
+++ b/nips/nip-43/kind-28936/schema.yaml
@@ -1,0 +1,23 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind28936
+description: "NIP-43 Leave Request event (relay access management)"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 28936
+        errorMessage: "kind must equal 28936"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/protected.yaml"
+            errorMessage:
+              contains: "tags must include a protected event tag ([\"-\"])"
+    required:
+      - kind
+      - tags

--- a/nips/nip-43/kind-8000/samples/invalid.missing-protected.json
+++ b/nips/nip-43/kind-8000/samples/invalid.missing-protected.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 8000,
+  "tags": [
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-43/kind-8000/samples/valid.json
+++ b/nips/nip-43/kind-8000/samples/valid.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 8000,
+  "tags": [
+    ["-"],
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-43/kind-8000/schema.yaml
+++ b/nips/nip-43/kind-8000/schema.yaml
@@ -1,0 +1,27 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind8000
+description: "NIP-43 Add User event (relay access management)"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 8000
+        errorMessage: "kind must equal 8000"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/protected.yaml"
+            errorMessage:
+              contains: "tags must include a protected event tag ([\"-\"])"
+          - contains:
+              $ref: "@/tag/p.yaml"
+            errorMessage:
+              contains: "tags must include a p tag with the added member's pubkey"
+    required:
+      - kind
+      - tags

--- a/nips/nip-43/kind-8001/samples/invalid.missing-p-tag.json
+++ b/nips/nip-43/kind-8001/samples/invalid.missing-p-tag.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 8001,
+  "tags": [
+    ["-"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-43/kind-8001/samples/valid.json
+++ b/nips/nip-43/kind-8001/samples/valid.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 8001,
+  "tags": [
+    ["-"],
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-43/kind-8001/schema.yaml
+++ b/nips/nip-43/kind-8001/schema.yaml
@@ -1,0 +1,27 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind8001
+description: "NIP-43 Remove User event (relay access management)"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 8001
+        errorMessage: "kind must equal 8001"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/protected.yaml"
+            errorMessage:
+              contains: "tags must include a protected event tag ([\"-\"])"
+          - contains:
+              $ref: "@/tag/p.yaml"
+            errorMessage:
+              contains: "tags must include a p tag with the removed member's pubkey"
+    required:
+      - kind
+      - tags

--- a/nips/nip-43/tag/claim/schema.yaml
+++ b/nips/nip-43/tag/claim/schema.yaml
@@ -5,10 +5,10 @@ allOf:
     minItems: 2
     maxItems: 2
     items:
-      - const: "layer"
+      - const: "claim"
       - type: string
         minLength: 1
-        description: "Payment layer (e.g. onchain, lightning, liquid)"
+        description: "Invite code string"
     additionalItems: false
     errorMessage:
-      minItems: "layer tag must have at least 2 elements"
+      minItems: "claim tag must have at least 2 elements"

--- a/nips/nip-43/tag/member/schema.yaml
+++ b/nips/nip-43/tag/member/schema.yaml
@@ -1,0 +1,14 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "member"
+      - allOf:
+          - $ref: "@/secp256k1.yaml"
+        description: "Hex-encoded pubkey of the member"
+    additionalItems: false
+    errorMessage:
+      minItems: "member tag must have at least 2 elements"

--- a/nips/nip-43/tag/protected/schema.yaml
+++ b/nips/nip-43/tag/protected/schema.yaml
@@ -1,0 +1,13 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+title: protectedTag
+description: 'Protected event tag ("-"). The tag name is a single dash character, indicating the event is only meant to be consumed by the relay it was published to.'
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 1
+    maxItems: 1
+    items:
+      - const: "-"
+    additionalItems: false
+    errorMessage:
+      minItems: "protected tag must have at least 1 element"

--- a/nips/nip-52/kind-31923/samples/valid.json
+++ b/nips/nip-52/kind-31923/samples/valid.json
@@ -8,6 +8,7 @@
   "tags": [
     ["d", "event-31923-1"],
     ["title", "Workshops"],
+    ["D", "20402"],
     ["start", "1764720000"],
     ["end", "1764752400"],
     ["start_tzid", "America/Denver"],

--- a/nips/nip-52/kind-31923/schema.yaml
+++ b/nips/nip-52/kind-31923/schema.yaml
@@ -20,6 +20,18 @@ allOf:
               $ref: "@/tag/title.yaml"
             errorMessage:
               contains: "tags must include a title tag"
+          # required: D (day-granularity unix timestamp)
+          - contains:
+              allOf:
+                - $ref: "@/tag.yaml"
+                - type: array
+                  minItems: 2
+                  items:
+                    - const: "D"
+                    - type: string
+                      pattern: '^[0-9]+$'
+            errorMessage:
+              contains: "tags must include a D tag with a day-granularity unix timestamp"
           # required: start (unix timestamp in seconds as string)
           - contains:
               allOf:

--- a/nips/nip-52/tag/start_tzid/schema.yaml
+++ b/nips/nip-52/tag/start_tzid/schema.yaml
@@ -7,6 +7,8 @@ allOf:
       - const: "start_tzid"
       - type: string
         description: "IANA Time Zone Database identifier"
-        pattern: '^[A-Za-z0-9_]+(?:\/[A-Za-z0-9_+\-]+)*$'
+        pattern: '^[A-Za-z0-9_\-+]+(?:\/[A-Za-z0-9_\-+]+)*$'
     additionalItems: false
+    errorMessage:
+      minItems: "start_tzid tag must have at least 2 elements"
 

--- a/nips/nip-54/kind-30819/samples/invalid.non-empty-content.json
+++ b/nips/nip-54/kind-30819/samples/invalid.non-empty-content.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 30819,
+  "tags": [
+    ["d", "btc"],
+    ["a", "30818:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:bitcoin", "wss://relay.example.com"]
+  ],
+  "content": "this should be empty",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-54/kind-30819/samples/valid.json
+++ b/nips/nip-54/kind-30819/samples/valid.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 30819,
+  "tags": [
+    ["d", "btc"],
+    ["a", "30818:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:bitcoin", "wss://relay.example.com"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-54/kind-30819/schema.yaml
+++ b/nips/nip-54/kind-30819/schema.yaml
@@ -1,0 +1,33 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind30819
+description: "NIP-54 Wiki Redirect event"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 30819
+        errorMessage: "kind must equal 30819"
+      content:
+        type: string
+        maxLength: 0
+        description: "Content must be an empty string"
+        errorMessage: "content must be an empty string"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/d.yaml"
+            errorMessage:
+              contains: "tags must include a d tag with the normalized source topic"
+          - contains:
+              $ref: "@/tag/a.yaml"
+            errorMessage:
+              contains: "tags must include an a tag referencing the target wiki article"
+    required:
+      - kind
+      - content
+      - tags

--- a/nips/nip-54/kind-818/samples/invalid.missing-a-tag.json
+++ b/nips/nip-54/kind-818/samples/invalid.missing-a-tag.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 818,
+  "tags": [
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["e", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", "wss://relay.example.com", "source"]
+  ],
+  "content": "Fixed a typo.",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-54/kind-818/samples/valid.json
+++ b/nips/nip-54/kind-818/samples/valid.json
@@ -1,0 +1,13 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 818,
+  "tags": [
+    ["a", "30818:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:bitcoin", "wss://relay.example.com"],
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["e", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", "wss://relay.example.com", "source"]
+  ],
+  "content": "Fixed a typo in the introduction section.",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-54/kind-818/schema.yaml
+++ b/nips/nip-54/kind-818/schema.yaml
@@ -1,0 +1,41 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind818
+description: "NIP-54 Wiki Merge Request event"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 818
+        errorMessage: "kind must equal 818"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/a.yaml"
+            errorMessage:
+              contains: "tags must include an a tag referencing the target wiki article"
+          - contains:
+              $ref: "@/tag/p.yaml"
+            errorMessage:
+              contains: "tags must include a p tag for the destination article owner"
+          - contains:
+              allOf:
+                - $ref: "@/tag.yaml"
+                - type: array
+                  minItems: 4
+                  items:
+                    - const: "e"
+                    - type: string
+                      pattern: '^[a-f0-9]{64}$'
+                    - type: string
+                    - const: "source"
+                  additionalItems: false
+            errorMessage:
+              contains: "tags must include an e tag with 'source' marker referencing the version to merge"
+    required:
+      - kind
+      - tags

--- a/nips/nip-59/kind-1059/samples/invalid.wrong-kind.json
+++ b/nips/nip-59/kind-1059/samples/invalid.wrong-kind.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1060,
+  "tags": [
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"]
+  ],
+  "content": "encrypted-seal-content",
+  "sig": "ddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+}

--- a/nips/nip-59/kind-1059/samples/valid.no-p-tag.json
+++ b/nips/nip-59/kind-1059/samples/valid.no-p-tag.json
@@ -3,9 +3,7 @@
   "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
   "created_at": 1670000000,
   "kind": 1059,
-  "tags": [
-    ["t", "nostr"]
-  ],
+  "tags": [],
   "content": "nip44-encrypted-seal-payload-here",
   "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
 }

--- a/nips/nip-59/kind-1059/schema.yaml
+++ b/nips/nip-59/kind-1059/schema.yaml
@@ -21,11 +21,5 @@ allOf:
         type: array
         items:
           $ref: "@/tag.yaml"
-        minItems: 1
-        allOf:
-          - contains:
-              $ref: "@/tag/p.yaml"
-            errorMessage:
-              contains: "tags must include a p tag"
     required:
       - kind

--- a/nips/nip-5A/kind-15128/samples/invalid.has-d-tag.json
+++ b/nips/nip-5A/kind-15128/samples/invalid.has-d-tag.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1727373475,
+  "kind": 15128,
+  "tags": [
+    ["d", "blog"],
+    ["path", "/index.html", "186ea5fd14e88fd1ac49351759e7ab906fa94892002b60bf7f5a428f28ca1c99"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-5A/kind-15128/samples/invalid.missing-path.json
+++ b/nips/nip-5A/kind-15128/samples/invalid.missing-path.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1727373475,
+  "kind": 15128,
+  "tags": [
+    ["title", "My Nostr Site"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-5A/kind-15128/samples/valid.json
+++ b/nips/nip-5A/kind-15128/samples/valid.json
@@ -1,0 +1,17 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1727373475,
+  "kind": 15128,
+  "tags": [
+    ["path", "/index.html", "186ea5fd14e88fd1ac49351759e7ab906fa94892002b60bf7f5a428f28ca1c99"],
+    ["path", "/about.html", "a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456"],
+    ["path", "/favicon.ico", "fedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321"],
+    ["server", "https://blossom.example.com"],
+    ["title", "My Nostr Site"],
+    ["description", "A static website hosted on Nostr"],
+    ["source", "https://github.com/example/my-nostr-site"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-5A/kind-15128/schema.yaml
+++ b/nips/nip-5A/kind-15128/schema.yaml
@@ -1,0 +1,36 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind15128
+description: "NIP-5A Root Site Manifest event"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 15128
+        errorMessage: "kind must equal 15128"
+      content:
+        type: string
+        maxLength: 0
+        description: "Content must be empty"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/path.yaml"
+            errorMessage:
+              contains: "tags must include at least one path tag"
+          - not:
+              contains:
+                allOf:
+                  - $ref: "@/tag.yaml"
+                  - type: array
+                    items:
+                      - const: "d"
+            errorMessage:
+              not: "root site manifest must not include a d tag"
+    required:
+      - kind
+      - tags

--- a/nips/nip-5A/kind-35128/samples/invalid.missing-d-tag.json
+++ b/nips/nip-5A/kind-35128/samples/invalid.missing-d-tag.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1727373475,
+  "kind": 35128,
+  "tags": [
+    ["path", "/index.html", "186ea5fd14e88fd1ac49351759e7ab906fa94892002b60bf7f5a428f28ca1c99"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-5A/kind-35128/samples/invalid.missing-path.json
+++ b/nips/nip-5A/kind-35128/samples/invalid.missing-path.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1727373475,
+  "kind": 35128,
+  "tags": [
+    ["d", "blog"],
+    ["title", "My Blog"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-5A/kind-35128/samples/valid.json
+++ b/nips/nip-5A/kind-35128/samples/valid.json
@@ -1,0 +1,17 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1727373475,
+  "kind": 35128,
+  "tags": [
+    ["d", "blog"],
+    ["path", "/index.html", "186ea5fd14e88fd1ac49351759e7ab906fa94892002b60bf7f5a428f28ca1c99"],
+    ["path", "/post.html", "a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456"],
+    ["server", "https://blossom.example.com"],
+    ["title", "My Blog"],
+    ["description", "A blog hosted on Nostr"],
+    ["source", "https://github.com/example/my-nostr-blog"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-5A/kind-35128/schema.yaml
+++ b/nips/nip-5A/kind-35128/schema.yaml
@@ -1,0 +1,31 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind35128
+description: "NIP-5A Named Site Manifest event"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 35128
+        errorMessage: "kind must equal 35128"
+      content:
+        type: string
+        maxLength: 0
+        description: "Content must be empty"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 2
+        allOf:
+          - contains:
+              $ref: "@/tag/d.yaml"
+            errorMessage:
+              contains: "tags must include a d tag with the site identifier"
+          - contains:
+              $ref: "@/tag/path.yaml"
+            errorMessage:
+              contains: "tags must include at least one path tag"
+    required:
+      - kind
+      - tags

--- a/nips/nip-5A/tag/path/schema.yaml
+++ b/nips/nip-5A/tag/path/schema.yaml
@@ -1,0 +1,17 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 3
+    maxItems: 3
+    items:
+      - const: "path"
+      - type: string
+        pattern: '^/.+'
+        description: "Absolute path ending with a filename and extension"
+      - type: string
+        pattern: '^[a-f0-9]{64}$'
+        description: "SHA-256 hash of the file served at this path"
+    additionalItems: false
+    errorMessage:
+      minItems: "path tag must have at least 3 elements"

--- a/nips/nip-5A/tag/source/schema.yaml
+++ b/nips/nip-5A/tag/source/schema.yaml
@@ -1,0 +1,14 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "source"
+      - type: string
+        pattern: '^https?://.+'
+        description: "URL to the site source code repository or archive"
+    additionalItems: false
+    errorMessage:
+      minItems: "source tag must have at least 2 elements"

--- a/nips/nip-60/kind-17375/samples/invalid.wrong-kind.json
+++ b/nips/nip-60/kind-17375/samples/invalid.wrong-kind.json
@@ -2,8 +2,8 @@
   "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
   "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
   "created_at": 1670000000,
-  "kind": 17375,
+  "kind": 17376,
   "tags": [],
-  "content": "encrypted-wallet-data",
-  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+  "content": "encrypted-wallet-content",
+  "sig": "ddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
 }

--- a/nips/nip-60/kind-17375/schema.yaml
+++ b/nips/nip-60/kind-17375/schema.yaml
@@ -8,14 +8,9 @@ allOf:
       kind:
         const: 17375
         errorMessage: "kind must equal 17375"
-      tags:
-        type: array
-        items:
-          $ref: "@/tag.yaml"
-        allOf:
-          - contains:
-              $ref: "@/tag/mint.yaml"
-            errorMessage:
-              contains: "tags must include a mint tag"
+      content:
+        type: string
+        minLength: 1
+        description: "NIP-44 encrypted content containing wallet data (privkey, mint URLs)"
     required:
-      - tags
+      - kind

--- a/nips/nip-60/kind-17375/schema.yaml
+++ b/nips/nip-60/kind-17375/schema.yaml
@@ -12,5 +12,7 @@ allOf:
         type: string
         minLength: 1
         description: "NIP-44 encrypted content containing wallet data (privkey, mint URLs)"
+        errorMessage:
+          minLength: "content must be a non-empty NIP-44 encrypted payload"
     required:
       - kind

--- a/nips/nip-62/kind-62/samples/valid.all-relays.json
+++ b/nips/nip-62/kind-62/samples/valid.all-relays.json
@@ -2,8 +2,10 @@
   "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
   "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
   "created_at": 1670000000,
-  "kind": 17375,
-  "tags": [],
-  "content": "encrypted-wallet-data",
+  "kind": 62,
+  "tags": [
+    ["relay", "ALL_RELAYS"]
+  ],
+  "content": "",
   "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
 }

--- a/nips/nip-62/kind-62/schema.yaml
+++ b/nips/nip-62/kind-62/schema.yaml
@@ -13,9 +13,19 @@ allOf:
         items:
           $ref: "@/tag.yaml"
         contains:
-          $ref: "@/tag/relay.yaml"
+          allOf:
+            - $ref: "@/tag.yaml"
+            - type: array
+              minItems: 2
+              items:
+                - const: "relay"
+                - type: string
+                  anyOf:
+                    - pattern: '^(ws://|wss://).+$'
+                    - const: "ALL_RELAYS"
+              additionalItems: false
         errorMessage:
-          contains: "tags must include at least one relay tag"
+          contains: "tags must include at least one relay tag (ws(s):// URL or ALL_RELAYS)"
     required:
       - kind
       - tags

--- a/nips/nip-65/kind-10002/schema.yaml
+++ b/nips/nip-65/kind-10002/schema.yaml
@@ -1,17 +1,22 @@
 $schema: http://json-schema.org/draft-07/schema#
 title: kind10002
-allOf: 
+allOf:
   - $ref: "@/note.yaml"
   - type: object
-    properties: 
-      tags: 
+    properties:
+      kind:
+        const: 10002
+        errorMessage: "kind must equal 10002"
+      tags:
         type: array
-        items: 
+        items:
+          $ref: "@/tag.yaml"
+        contains:
           $ref: "@/tag/r.yaml"
-        additionalItems: false
         minItems: 1
         errorMessage:
-          type: "tags must be an array of r tags"
-          minItems: "tags array must have at least one r tag"
+          contains: "tags must include at least one r tag with a relay URL"
+          minItems: "tags array must have at least one tag"
     required:
+      - kind
       - tags

--- a/nips/nip-69/tag/network/schema.yaml
+++ b/nips/nip-69/tag/network/schema.yaml
@@ -7,5 +7,8 @@ allOf:
     items:
       - const: "network"
       - type: string
-        enum: ["mainnet", "testnet", "signet"]
+        minLength: 1
+        description: "Bitcoin network (e.g. mainnet, testnet, signet)"
     additionalItems: false
+    errorMessage:
+      minItems: "network tag must have at least 2 elements"

--- a/nips/nip-72/kind-4550/samples/valid.json
+++ b/nips/nip-72/kind-4550/samples/valid.json
@@ -5,6 +5,7 @@
   "kind": 4550,
   "tags": [
     ["a", "34550:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:test"],
+    ["e", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", "", "reply"],
     ["p", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"]
   ],
   "content": "",

--- a/nips/nip-72/kind-4550/schema.yaml
+++ b/nips/nip-72/kind-4550/schema.yaml
@@ -18,6 +18,10 @@ allOf:
             errorMessage:
               contains: "tags must include an a tag referencing the community"
           - contains:
+              $ref: "@/tag/e.yaml"
+            errorMessage:
+              contains: "tags must include an e tag referencing the approved post"
+          - contains:
               $ref: "@/tag/p.yaml"
             errorMessage:
               contains: "tags must include a p tag with the post author pubkey"

--- a/nips/nip-73/tag/k/schema.yaml
+++ b/nips/nip-73/tag/k/schema.yaml
@@ -15,3 +15,4 @@ allOf:
     additionalItems: false
     errorMessage:
       minItems: "k tag must be ['k', <type>]"
+      maxItems: "k tag must be exactly ['k', <type>]"

--- a/nips/nip-73/tag/k/schema.yaml
+++ b/nips/nip-73/tag/k/schema.yaml
@@ -5,15 +5,13 @@ allOf:
   - $ref: "@/tag.yaml"
   - type: array
     minItems: 2
-    maxItems: 3
+    maxItems: 2
     items:
       - const: "k"
       - type: string
         minLength: 1
-        pattern: "^[A-Za-z0-9][A-Za-z0-9._+-]*(?::[A-Za-z0-9][A-Za-z0-9._+-]*)*$"
-        description: Type identifier for the external resource
-      - type: string
-        minLength: 1
-        description: Optional subtype or hint for the external resource
+        pattern: "^(#|[A-Za-z0-9][A-Za-z0-9._+-]*(?::[A-Za-z0-9][A-Za-z0-9._+-]*)*)$"
+        description: Type identifier for the external resource (e.g. isbn, geo, podcast:guid, #)
+    additionalItems: false
     errorMessage:
-      minItems: "k tag must be ['k', <type>, ...]"
+      minItems: "k tag must be ['k', <type>]"

--- a/nips/nip-85/kind-30383/samples/invalid.non-empty-content.json
+++ b/nips/nip-85/kind-30383/samples/invalid.non-empty-content.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 30383,
+  "tags": [
+    ["d", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"]
+  ],
+  "content": "this should be empty",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-85/kind-30383/samples/valid.json
+++ b/nips/nip-85/kind-30383/samples/valid.json
@@ -1,0 +1,14 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 30383,
+  "tags": [
+    ["d", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["rank", "75"],
+    ["reaction_cnt", "42"],
+    ["zap_amount", "10000"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-85/kind-30383/schema.yaml
+++ b/nips/nip-85/kind-30383/schema.yaml
@@ -1,0 +1,29 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind30383
+description: "NIP-85 Trusted Assertion (event as subject)"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 30383
+        errorMessage: "kind must equal 30383"
+      content:
+        type: string
+        maxLength: 0
+        description: "Content must be an empty string"
+        errorMessage: "content must be an empty string"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/d.yaml"
+            errorMessage:
+              contains: "tags must include a d tag with the target event ID"
+    required:
+      - kind
+      - content
+      - tags

--- a/nips/nip-85/kind-30384/samples/invalid.missing-d-tag.json
+++ b/nips/nip-85/kind-30384/samples/invalid.missing-d-tag.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 30384,
+  "tags": [
+    ["rank", "90"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-85/kind-30384/samples/valid.json
+++ b/nips/nip-85/kind-30384/samples/valid.json
@@ -1,0 +1,14 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 30384,
+  "tags": [
+    ["d", "30023:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:my-article"],
+    ["rank", "90"],
+    ["comment_cnt", "15"],
+    ["zap_cnt", "8"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-85/kind-30384/schema.yaml
+++ b/nips/nip-85/kind-30384/schema.yaml
@@ -1,0 +1,29 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind30384
+description: "NIP-85 Trusted Assertion (addressable event as subject)"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 30384
+        errorMessage: "kind must equal 30384"
+      content:
+        type: string
+        maxLength: 0
+        description: "Content must be an empty string"
+        errorMessage: "content must be an empty string"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/d.yaml"
+            errorMessage:
+              contains: "tags must include a d tag with the target event address"
+    required:
+      - kind
+      - content
+      - tags

--- a/nips/nip-87/kind-38172/samples/invalid.missing-u-tag.json
+++ b/nips/nip-87/kind-38172/samples/invalid.missing-u-tag.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 38172,
+  "tags": [
+    ["d", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["n", "mainnet"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-87/kind-38172/samples/valid.json
+++ b/nips/nip-87/kind-38172/samples/valid.json
@@ -1,0 +1,14 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 38172,
+  "tags": [
+    ["d", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["u", "https://cashu.example.com"],
+    ["nuts", "1,2,3,4,5,6,7"],
+    ["n", "mainnet"]
+  ],
+  "content": "{\"name\":\"Example Mint\",\"about\":\"A test cashu mint\"}",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-87/kind-38172/schema.yaml
+++ b/nips/nip-87/kind-38172/schema.yaml
@@ -1,0 +1,35 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind38172
+description: "NIP-87 Cashu Mint Announcement event"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 38172
+        errorMessage: "kind must equal 38172"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/d.yaml"
+            errorMessage:
+              contains: "tags must include a d tag with the mint pubkey"
+          - contains:
+              $ref: "@/tag/u.yaml"
+            errorMessage:
+              contains: "tags must include a u tag with the mint URL"
+          - contains:
+              $ref: "@/tag/nuts.yaml"
+            errorMessage:
+              contains: "tags must include a nuts tag with supported NUT numbers"
+          - contains:
+              $ref: "@/tag/n.yaml"
+            errorMessage:
+              contains: "tags must include an n tag with the network identifier"
+    required:
+      - kind
+      - tags

--- a/nips/nip-87/kind-38173/samples/invalid.missing-d-tag.json
+++ b/nips/nip-87/kind-38173/samples/invalid.missing-d-tag.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 38173,
+  "tags": [
+    ["u", "fed11qgqzc2nhwden5te0vejkg6tdd9h8gepwvejhyamrvaak8e6q"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-87/kind-38173/samples/valid.json
+++ b/nips/nip-87/kind-38173/samples/valid.json
@@ -1,0 +1,14 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 38173,
+  "tags": [
+    ["d", "federation-id-abc123"],
+    ["u", "fed11qgqzc2nhwden5te0vejkg6tdd9h8gepwvejhyamrvaak8e6q"],
+    ["modules", "lightning,wallet,mint"],
+    ["n", "mainnet"]
+  ],
+  "content": "{\"name\":\"Example Federation\"}",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-87/kind-38173/schema.yaml
+++ b/nips/nip-87/kind-38173/schema.yaml
@@ -1,0 +1,45 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind38173
+description: "NIP-87 Fedimint Announcement event"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 38173
+        errorMessage: "kind must equal 38173"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/d.yaml"
+            errorMessage:
+              contains: "tags must include a d tag with the federation ID"
+          # u tag is inline because its value is an invite code, not a URL;
+          # reusing the NIP-61 u tag (which expects a URL) would be incorrect.
+          - contains:
+              allOf:
+                - $ref: "@/tag.yaml"
+                - type: array
+                  minItems: 2
+                  items:
+                    - const: "u"
+                    - type: string
+                      minLength: 1
+                  additionalItems: false
+            errorMessage:
+              contains: "tags must include a u tag with a fedimint invite code"
+          - contains:
+              $ref: "@/tag/modules.yaml"
+            errorMessage:
+              contains: "tags must include a modules tag with supported module names"
+          - contains:
+              $ref: "@/tag/n.yaml"
+            errorMessage:
+              contains: "tags must include an n tag with the network identifier"
+    required:
+      - kind
+      - tags

--- a/nips/nip-87/tag/modules/schema.yaml
+++ b/nips/nip-87/tag/modules/schema.yaml
@@ -5,10 +5,11 @@ allOf:
     minItems: 2
     maxItems: 2
     items:
-      - const: "layer"
+      - const: "modules"
       - type: string
         minLength: 1
-        description: "Payment layer (e.g. onchain, lightning, liquid)"
+        pattern: '^[A-Za-z0-9_]+(,[A-Za-z0-9_]+)*$'
+        description: "Comma-separated module names"
     additionalItems: false
     errorMessage:
-      minItems: "layer tag must have at least 2 elements"
+      minItems: "modules tag must have at least 2 elements"

--- a/nips/nip-87/tag/n/schema.yaml
+++ b/nips/nip-87/tag/n/schema.yaml
@@ -5,10 +5,10 @@ allOf:
     minItems: 2
     maxItems: 2
     items:
-      - const: "layer"
+      - const: "n"
       - type: string
-        minLength: 1
-        description: "Payment layer (e.g. onchain, lightning, liquid)"
+        enum: ["mainnet", "testnet", "signet", "regtest"]
+        description: "Bitcoin network identifier"
     additionalItems: false
     errorMessage:
-      minItems: "layer tag must have at least 2 elements"
+      minItems: "n tag must have at least 2 elements"

--- a/nips/nip-87/tag/nuts/schema.yaml
+++ b/nips/nip-87/tag/nuts/schema.yaml
@@ -5,10 +5,10 @@ allOf:
     minItems: 2
     maxItems: 2
     items:
-      - const: "layer"
+      - const: "nuts"
       - type: string
-        minLength: 1
-        description: "Payment layer (e.g. onchain, lightning, liquid)"
+        pattern: '^[0-9]+(,[0-9]+)*$'
+        description: "Comma-separated NUT specification numbers"
     additionalItems: false
     errorMessage:
-      minItems: "layer tag must have at least 2 elements"
+      minItems: "nuts tag must have at least 2 elements"

--- a/nips/nip-90/kind-6000/samples/valid.json
+++ b/nips/nip-90/kind-6000/samples/valid.json
@@ -6,7 +6,7 @@
   "tags": [
     ["e", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"],
     ["p", "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"],
-    ["request", "{\"id\":\"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\"}"]
+    ["amount", "1000"]
   ],
   "content": "Extracted text content here",
   "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"

--- a/nips/nip-90/kind-6000/schema.yaml
+++ b/nips/nip-90/kind-6000/schema.yaml
@@ -26,7 +26,7 @@ allOf:
             errorMessage:
               contains: "tags must include a p tag with the customer's pubkey"
           - contains:
-              $ref: "nips/nip-90/tag/amount/schema.yaml"
+              $ref: "@/tag/amount.yaml"
             errorMessage:
               contains: "tags must include an amount tag with the charge in millisats"
           - if:
@@ -37,6 +37,8 @@ allOf:
             then:
               contains:
                 $ref: "@/tag/request.yaml"
+              errorMessage:
+                contains: "if a request tag is present, it must match the request tag schema"
     required:
       - kind
       - tags

--- a/nips/nip-90/kind-6000/schema.yaml
+++ b/nips/nip-90/kind-6000/schema.yaml
@@ -15,7 +15,7 @@ allOf:
           $ref: "@/tag.yaml"
         minItems: 3
         errorMessage:
-          minItems: "tags must contain at least three tags (e, p, request)"
+          minItems: "tags must contain at least three tags (e, p, amount)"
         allOf:
           - contains:
               $ref: "@/tag/e.yaml"
@@ -26,9 +26,17 @@ allOf:
             errorMessage:
               contains: "tags must include a p tag with the customer's pubkey"
           - contains:
-              $ref: "@/tag/request.yaml"
+              $ref: "nips/nip-90/tag/amount/schema.yaml"
             errorMessage:
-              contains: "tags must include a request tag with the original job request JSON"
+              contains: "tags must include an amount tag with the charge in millisats"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "request"
+            then:
+              contains:
+                $ref: "@/tag/request.yaml"
     required:
       - kind
       - tags

--- a/nips/nip-90/kind-6300/samples/valid.json
+++ b/nips/nip-90/kind-6300/samples/valid.json
@@ -6,7 +6,7 @@
   "tags": [
     ["e", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"],
     ["p", "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"],
-    ["request", "{\"id\":\"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\"}"]
+    ["amount", "5000"]
   ],
   "content": "",
   "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"

--- a/nips/nip-90/kind-6300/schema.yaml
+++ b/nips/nip-90/kind-6300/schema.yaml
@@ -14,7 +14,7 @@ allOf:
           $ref: "@/tag.yaml"
         minItems: 3
         errorMessage:
-          minItems: "tags must contain at least three tags (e, p, request)"
+          minItems: "tags must contain at least three tags (e, p, amount)"
         allOf:
           - contains:
               $ref: "@/tag/e.yaml"
@@ -25,9 +25,17 @@ allOf:
             errorMessage:
               contains: "tags must include a p tag with the customer's pubkey"
           - contains:
-              $ref: "@/tag/request.yaml"
+              $ref: "nips/nip-90/tag/amount/schema.yaml"
             errorMessage:
-              contains: "tags must include a request tag with the original job request JSON"
+              contains: "tags must include an amount tag with the charge in millisats"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "request"
+            then:
+              contains:
+                $ref: "@/tag/request.yaml"
     required:
       - kind
       - tags

--- a/nips/nip-90/kind-6301/samples/valid.json
+++ b/nips/nip-90/kind-6301/samples/valid.json
@@ -6,7 +6,7 @@
   "tags": [
     ["e", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"],
     ["p", "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"],
-    ["request", "{\"id\":\"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\"}"]
+    ["amount", "5000"]
   ],
   "content": "",
   "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"

--- a/nips/nip-90/kind-6301/schema.yaml
+++ b/nips/nip-90/kind-6301/schema.yaml
@@ -14,7 +14,7 @@ allOf:
           $ref: "@/tag.yaml"
         minItems: 3
         errorMessage:
-          minItems: "tags must contain at least three tags (e, p, request)"
+          minItems: "tags must contain at least three tags (e, p, amount)"
         allOf:
           - contains:
               $ref: "@/tag/e.yaml"
@@ -25,9 +25,17 @@ allOf:
             errorMessage:
               contains: "tags must include a p tag with the customer's pubkey"
           - contains:
-              $ref: "@/tag/request.yaml"
+              $ref: "nips/nip-90/tag/amount/schema.yaml"
             errorMessage:
-              contains: "tags must include a request tag with the original job request JSON"
+              contains: "tags must include an amount tag with the charge in millisats"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "request"
+            then:
+              contains:
+                $ref: "@/tag/request.yaml"
     required:
       - kind
       - tags

--- a/nips/nip-90/tag/amount/schema.yaml
+++ b/nips/nip-90/tag/amount/schema.yaml
@@ -1,0 +1,18 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+description: "NIP-90 amount tag for job results: ['amount', '<millisats>', '<optional-bolt11>']"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 3
+    items:
+      - const: "amount"
+      - type: string
+        pattern: '^[0-9]+$'
+        description: "Amount charged in millisats"
+      - type: string
+        minLength: 1
+        description: "Optional bolt11 invoice"
+    additionalItems: false
+    errorMessage:
+      minItems: "amount tag must have at least 2 elements"

--- a/nips/nip-90/tag/bid/schema.yaml
+++ b/nips/nip-90/tag/bid/schema.yaml
@@ -3,13 +3,12 @@ allOf:
   - $ref: "@/tag.yaml"
   - type: array
     minItems: 2
-    maxItems: 3
+    maxItems: 2
     items:
       - const: "bid"
       - type: string
         pattern: "^[0-9]+$"
-        description: "Bid amount in millisats"
-      - type: string
-        pattern: "^[0-9]+$"
-        description: "Maximum bid amount in millisats"
+        description: "Maximum millisats the user is willing to pay"
     additionalItems: false
+    errorMessage:
+      minItems: "bid tag must have at least 2 elements"

--- a/nips/nip-90/tag/i/schema.yaml
+++ b/nips/nip-90/tag/i/schema.yaml
@@ -8,5 +8,9 @@ allOf:
       - type: string
         description: "Input data (URL, event ID, job ID, or text)"
       - type: string
-        description: "Input type (url, event, job, text)"
-    additionalItems: true
+        enum: ["url", "event", "job", "text"]
+        description: "Input type"
+    additionalItems:
+      type: string
+    errorMessage:
+      minItems: "i tag must have at least 3 elements"

--- a/nips/nip-99/kind-30402/schema.yaml
+++ b/nips/nip-99/kind-30402/schema.yaml
@@ -10,6 +10,10 @@ allOf:
         errorMessage: "kind must equal 30402"
       tags:
         type: array
+        contains:
+          $ref: "@/tag/d.yaml"
+        errorMessage:
+          contains: "tags must include a d tag (required for addressable events)"
         items:
           allOf:
             # title

--- a/nips/nip-99/kind-30403/schema.yaml
+++ b/nips/nip-99/kind-30403/schema.yaml
@@ -10,6 +10,10 @@ allOf:
         errorMessage: "kind must equal 30403"
       tags:
         type: array
+        contains:
+          $ref: "@/tag/d.yaml"
+        errorMessage:
+          contains: "tags must include a d tag (required for addressable events)"
         items:
           allOf:
             # title

--- a/nips/nip-A0/kind-1244/schema.yaml
+++ b/nips/nip-A0/kind-1244/schema.yaml
@@ -13,6 +13,24 @@ allOf:
         pattern: "^https?://\\S+$"
         description: "URL pointing directly to an audio file"
         errorMessage: "content must be a URL to an audio file"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        allOf:
+          # NIP-22 requires uppercase K tag for the root event kind
+          - contains:
+              allOf:
+                - $ref: "@/tag.yaml"
+                - type: array
+                  minItems: 2
+                  items:
+                    - const: "K"
+                    - type: string
+                      pattern: '^[0-9]+$'
+            errorMessage:
+              contains: "tags must include a K tag with the root event kind (NIP-22)"
     required:
       - kind
       - content
+      - tags

--- a/nips/nip-A4/kind-24/samples/invalid.missing-p-tag.json
+++ b/nips/nip-A4/kind-24/samples/invalid.missing-p-tag.json
@@ -1,0 +1,9 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 24,
+  "tags": [],
+  "content": "Hey, just wanted to let you know!",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-A4/kind-24/samples/valid.json
+++ b/nips/nip-A4/kind-24/samples/valid.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 24,
+  "tags": [
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "wss://relay.example.com"]
+  ],
+  "content": "Hey, just wanted to let you know the event is starting soon!",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-A4/kind-24/schema.yaml
+++ b/nips/nip-A4/kind-24/schema.yaml
@@ -1,0 +1,28 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind24
+description: "NIP-A4 Public Message event"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 24
+        errorMessage: "kind must equal 24"
+      content:
+        type: string
+        minLength: 1
+        description: "The message text in plain text"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/p.yaml"
+            errorMessage:
+              contains: "tags must include at least one p tag for the message receiver"
+    required:
+      - kind
+      - content
+      - tags

--- a/nips/nip-B0/kind-39701/samples/invalid.missing-d-tag.json
+++ b/nips/nip-B0/kind-39701/samples/invalid.missing-d-tag.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 39701,
+  "tags": [
+    ["title", "An Interesting Article"]
+  ],
+  "content": "A great article.",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-B0/kind-39701/samples/valid.json
+++ b/nips/nip-B0/kind-39701/samples/valid.json
@@ -1,0 +1,14 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 39701,
+  "tags": [
+    ["d", "example.com/interesting-article"],
+    ["title", "An Interesting Article"],
+    ["t", "nostr"],
+    ["t", "protocol"]
+  ],
+  "content": "A great article about the nostr protocol.",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-B0/kind-39701/schema.yaml
+++ b/nips/nip-B0/kind-39701/schema.yaml
@@ -1,0 +1,39 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind39701
+description: "NIP-B0 Web Bookmark event"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 39701
+        errorMessage: "kind must equal 39701"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/d.yaml"
+            errorMessage:
+              contains: "tags must include a d tag with the URL (without scheme)"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "title"
+            then:
+              contains:
+                $ref: "@/tag/title.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "published_at"
+            then:
+              contains:
+                $ref: "@/tag/published_at.yaml"
+    required:
+      - kind
+      - tags

--- a/nips/nip-C0/kind-1337/samples/invalid.empty-content.json
+++ b/nips/nip-C0/kind-1337/samples/invalid.empty-content.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1337,
+  "tags": [
+    ["l", "python"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-C0/kind-1337/samples/valid.json
+++ b/nips/nip-C0/kind-1337/samples/valid.json
@@ -1,0 +1,16 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1337,
+  "tags": [
+    ["l", "javascript"],
+    ["name", "hello-world.js"],
+    ["extension", "js"],
+    ["description", "A simple hello world example"],
+    ["runtime", "node v18.15.0"],
+    ["license", "MIT"]
+  ],
+  "content": "console.log('Hello, world!');",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-C0/kind-1337/schema.yaml
+++ b/nips/nip-C0/kind-1337/schema.yaml
@@ -1,0 +1,40 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind1337
+description: "NIP-C0 Code Snippet event"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 1337
+        errorMessage: "kind must equal 1337"
+      content:
+        type: string
+        minLength: 1
+        description: "The code snippet text"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "name"
+            then:
+              contains:
+                $ref: "@/tag/name.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "description"
+            then:
+              contains:
+                $ref: "@/tag/description.yaml"
+    required:
+      - kind
+      - content
+      - tags

--- a/nips/nkbip-03/kind-30/samples/invalid.missing-title.json
+++ b/nips/nkbip-03/kind-30/samples/invalid.missing-title.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 30,
+  "tags": [
+    ["c", "0:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"],
+    ["author", "John Smith"]
+  ],
+  "content": "Some cited text.",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nkbip-03/kind-30/samples/valid.json
+++ b/nips/nkbip-03/kind-30/samples/valid.json
@@ -1,0 +1,14 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 30,
+  "tags": [
+    ["c", "0:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", "wss://relay.example.com"],
+    ["published_on", "2024-01-15T12:00:00Z"],
+    ["title", "The Truth About Time"],
+    ["author", "John Smith", "npub1cccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"]
+  ],
+  "content": "Time is a social construct that shapes our daily lives.",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nkbip-03/kind-30/schema.yaml
+++ b/nips/nkbip-03/kind-30/schema.yaml
@@ -1,0 +1,43 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind30
+description: "NKBIP-03 Internal Nostr reference (citation)"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 30
+        errorMessage: "kind must equal 30"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/title.yaml"
+            errorMessage:
+              contains: "tags must include a title tag for the citation"
+          - contains:
+              $ref: "@/tag/author.yaml"
+            errorMessage:
+              contains: "tags must include an author tag"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "published_on"
+            then:
+              contains:
+                $ref: "@/tag/published_on.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "accessed_on"
+            then:
+              contains:
+                $ref: "@/tag/accessed_on.yaml"
+    required:
+      - kind
+      - tags

--- a/nips/nkbip-03/kind-31/samples/invalid.missing-u-tag.json
+++ b/nips/nkbip-03/kind-31/samples/invalid.missing-u-tag.json
@@ -1,0 +1,13 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 31,
+  "tags": [
+    ["accessed_on", "2024-03-15T10:30:00Z"],
+    ["title", "Understanding Nostr Protocol"],
+    ["author", "Alice Bob"]
+  ],
+  "content": "Some cited text.",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nkbip-03/kind-31/samples/valid.json
+++ b/nips/nkbip-03/kind-31/samples/valid.json
@@ -1,0 +1,14 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 31,
+  "tags": [
+    ["u", "https://example.com/article"],
+    ["accessed_on", "2024-03-15T10:30:00Z"],
+    ["title", "Understanding Nostr Protocol"],
+    ["author", "Alice Bob"]
+  ],
+  "content": "The Nostr protocol is a simple, open protocol for decentralized social networking.",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nkbip-03/kind-31/schema.yaml
+++ b/nips/nkbip-03/kind-31/schema.yaml
@@ -1,0 +1,51 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind31
+description: "NKBIP-03 External web reference (citation)"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 31
+        errorMessage: "kind must equal 31"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/u.yaml"
+            errorMessage:
+              contains: "tags must include a u tag with the URL of the citation"
+          - contains:
+              $ref: "@/tag/accessed_on.yaml"
+            errorMessage:
+              contains: "tags must include an accessed_on tag with the access date"
+          - contains:
+              $ref: "@/tag/title.yaml"
+            errorMessage:
+              contains: "tags must include a title tag for the citation"
+          - contains:
+              $ref: "@/tag/author.yaml"
+            errorMessage:
+              contains: "tags must include an author tag"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "published_on"
+            then:
+              contains:
+                $ref: "@/tag/published_on.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "version"
+            then:
+              contains:
+                $ref: "@/tag/version.yaml"
+    required:
+      - kind
+      - tags

--- a/nips/nkbip-03/kind-32/samples/invalid.missing-author.json
+++ b/nips/nkbip-03/kind-32/samples/invalid.missing-author.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 32,
+  "tags": [
+    ["accessed_on", "2024-06-01T00:00:00Z"],
+    ["title", "The Bitcoin Standard"]
+  ],
+  "content": "Some cited text.",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nkbip-03/kind-32/samples/valid.json
+++ b/nips/nkbip-03/kind-32/samples/valid.json
@@ -1,0 +1,17 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 32,
+  "tags": [
+    ["accessed_on", "2024-06-01T00:00:00Z"],
+    ["title", "The Bitcoin Standard"],
+    ["author", "Saifedean Ammous"],
+    ["published_on", "2018-03-23T00:00:00Z"],
+    ["published_by", "Wiley"],
+    ["page_range", "45-67"],
+    ["chapter_title", "Digital Money"]
+  ],
+  "content": "The most important application of the blockchain is as a monetary system.",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nkbip-03/kind-32/schema.yaml
+++ b/nips/nkbip-03/kind-32/schema.yaml
@@ -1,0 +1,79 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind32
+description: "NKBIP-03 Hardcopy reference (citation)"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 32
+        errorMessage: "kind must equal 32"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/accessed_on.yaml"
+            errorMessage:
+              contains: "tags must include an accessed_on tag"
+          - contains:
+              $ref: "@/tag/title.yaml"
+            errorMessage:
+              contains: "tags must include a title tag for the citation"
+          - contains:
+              $ref: "@/tag/author.yaml"
+            errorMessage:
+              contains: "tags must include an author tag"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "page_range"
+            then:
+              contains:
+                $ref: "@/tag/page_range.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "chapter_title"
+            then:
+              contains:
+                $ref: "@/tag/chapter_title.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "editor"
+            then:
+              contains:
+                $ref: "@/tag/editor.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "doi"
+            then:
+              contains:
+                $ref: "@/tag/doi.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "published_in"
+            then:
+              contains:
+                $ref: "@/tag/published_in.yaml"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "version"
+            then:
+              contains:
+                $ref: "@/tag/version.yaml"
+    required:
+      - kind
+      - tags

--- a/nips/nkbip-03/kind-33/samples/invalid.missing-llm.json
+++ b/nips/nkbip-03/kind-33/samples/invalid.missing-llm.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 33,
+  "tags": [
+    ["accessed_on", "2024-12-01T14:00:00Z"]
+  ],
+  "content": "Some AI-generated text.",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nkbip-03/kind-33/samples/valid.json
+++ b/nips/nkbip-03/kind-33/samples/valid.json
@@ -1,0 +1,14 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 33,
+  "tags": [
+    ["llm", "Claude 3.5 Sonnet"],
+    ["accessed_on", "2024-12-01T14:00:00Z"],
+    ["version", "claude-3-5-sonnet-20241022"],
+    ["summary", "Explain the nostr protocol in simple terms"]
+  ],
+  "content": "Nostr is a decentralized protocol for social networking that uses cryptographic keypairs.",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nkbip-03/kind-33/schema.yaml
+++ b/nips/nkbip-03/kind-33/schema.yaml
@@ -1,0 +1,35 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind33
+description: "NKBIP-03 Prompt reference (AI citation)"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 33
+        errorMessage: "kind must equal 33"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/llm.yaml"
+            errorMessage:
+              contains: "tags must include an llm tag identifying the language model"
+          - contains:
+              $ref: "@/tag/accessed_on.yaml"
+            errorMessage:
+              contains: "tags must include an accessed_on tag"
+          - if:
+              contains:
+                type: array
+                items:
+                  - const: "version"
+            then:
+              contains:
+                $ref: "@/tag/version.yaml"
+    required:
+      - kind
+      - tags

--- a/nips/nkbip-03/tag/accessed_on/schema.yaml
+++ b/nips/nkbip-03/tag/accessed_on/schema.yaml
@@ -1,0 +1,14 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "accessed_on"
+      - type: string
+        pattern: '^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2})?(\.\d+)?(Z|[+-]\d{2}:\d{2})?)?$'
+        description: "Date-time in ISO 8601 format"
+    additionalItems: false
+    errorMessage:
+      minItems: "accessed_on tag must have at least 2 elements"

--- a/nips/nkbip-03/tag/author/schema.yaml
+++ b/nips/nkbip-03/tag/author/schema.yaml
@@ -1,0 +1,15 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    items:
+      - const: "author"
+      - type: string
+        minLength: 1
+        description: "Author name for the citation"
+    additionalItems:
+      type: string
+      minLength: 1
+    errorMessage:
+      minItems: "author tag must have at least 2 elements"

--- a/nips/nkbip-03/tag/chapter_title/schema.yaml
+++ b/nips/nkbip-03/tag/chapter_title/schema.yaml
@@ -5,10 +5,10 @@ allOf:
     minItems: 2
     maxItems: 2
     items:
-      - const: "layer"
+      - const: "chapter_title"
       - type: string
         minLength: 1
-        description: "Payment layer (e.g. onchain, lightning, liquid)"
+        description: "Chapter or section the citation is found in"
     additionalItems: false
     errorMessage:
-      minItems: "layer tag must have at least 2 elements"
+      minItems: "chapter_title tag must have at least 2 elements"

--- a/nips/nkbip-03/tag/doi/schema.yaml
+++ b/nips/nkbip-03/tag/doi/schema.yaml
@@ -5,10 +5,11 @@ allOf:
     minItems: 2
     maxItems: 2
     items:
-      - const: "layer"
+      - const: "doi"
       - type: string
         minLength: 1
-        description: "Payment layer (e.g. onchain, lightning, liquid)"
+        pattern: '^10\.\d{4,9}/.+$'
+        description: "DOI number for the publication"
     additionalItems: false
     errorMessage:
-      minItems: "layer tag must have at least 2 elements"
+      minItems: "doi tag must have at least 2 elements"

--- a/nips/nkbip-03/tag/editor/schema.yaml
+++ b/nips/nkbip-03/tag/editor/schema.yaml
@@ -5,10 +5,10 @@ allOf:
     minItems: 2
     maxItems: 2
     items:
-      - const: "layer"
+      - const: "editor"
       - type: string
         minLength: 1
-        description: "Payment layer (e.g. onchain, lightning, liquid)"
+        description: "Editor of the publication"
     additionalItems: false
     errorMessage:
-      minItems: "layer tag must have at least 2 elements"
+      minItems: "editor tag must have at least 2 elements"

--- a/nips/nkbip-03/tag/llm/schema.yaml
+++ b/nips/nkbip-03/tag/llm/schema.yaml
@@ -1,0 +1,14 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    items:
+      - const: "llm"
+      - type: string
+        minLength: 1
+        description: "Language model identifier used for the prompt"
+    additionalItems:
+      type: string
+    errorMessage:
+      minItems: "llm tag must have at least 2 elements"

--- a/nips/nkbip-03/tag/page_range/schema.yaml
+++ b/nips/nkbip-03/tag/page_range/schema.yaml
@@ -5,10 +5,10 @@ allOf:
     minItems: 2
     maxItems: 2
     items:
-      - const: "layer"
+      - const: "page_range"
       - type: string
         minLength: 1
-        description: "Payment layer (e.g. onchain, lightning, liquid)"
+        description: "Pages the citation is found on"
     additionalItems: false
     errorMessage:
-      minItems: "layer tag must have at least 2 elements"
+      minItems: "page_range tag must have at least 2 elements"

--- a/nips/nkbip-03/tag/published_by/schema.yaml
+++ b/nips/nkbip-03/tag/published_by/schema.yaml
@@ -5,10 +5,10 @@ allOf:
     minItems: 2
     maxItems: 2
     items:
-      - const: "layer"
+      - const: "published_by"
       - type: string
         minLength: 1
-        description: "Payment layer (e.g. onchain, lightning, liquid)"
+        description: "Publisher of the citation"
     additionalItems: false
     errorMessage:
-      minItems: "layer tag must have at least 2 elements"
+      minItems: "published_by tag must have at least 2 elements"

--- a/nips/nkbip-03/tag/published_in/schema.yaml
+++ b/nips/nkbip-03/tag/published_in/schema.yaml
@@ -5,13 +5,12 @@ allOf:
     minItems: 2
     maxItems: 3
     items:
-      - const: "r"
+      - const: "published_in"
       - type: string
-        pattern: '^(ws://|wss://).+$'
-        description: "Relay URL"
+        minLength: 1
+        description: "Journal name"
       - type: string
-        enum: ["read", "write"]
-        description: "Optional read/write marker"
+        description: "Volume number"
     additionalItems: false
     errorMessage:
-      minItems: "r tag must have at least 2 elements"
+      minItems: "published_in tag must have at least 2 elements"

--- a/nips/nkbip-03/tag/published_on/schema.yaml
+++ b/nips/nkbip-03/tag/published_on/schema.yaml
@@ -1,0 +1,14 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "published_on"
+      - type: string
+        pattern: '^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2})?(\.\d+)?(Z|[+-]\d{2}:\d{2})?)?$'
+        description: "Date-time in ISO 8601 format"
+    additionalItems: false
+    errorMessage:
+      minItems: "published_on tag must have at least 2 elements"

--- a/nips/nkbip-03/tag/version/schema.yaml
+++ b/nips/nkbip-03/tag/version/schema.yaml
@@ -5,10 +5,10 @@ allOf:
     minItems: 2
     maxItems: 2
     items:
-      - const: "layer"
+      - const: "version"
       - type: string
         minLength: 1
-        description: "Payment layer (e.g. onchain, lightning, liquid)"
+        description: "Version or edition of the publication or model"
     additionalItems: false
     errorMessage:
-      minItems: "layer tag must have at least 2 elements"
+      minItems: "version tag must have at least 2 elements"


### PR DESCRIPTION
## Summary

Closes coverage gaps by adding JSON schemas for 21 event kinds across 9 NIPs, plus 20 new tag definitions and aliases. Includes 15 spec-audit fix commits addressing issues found across both new and pre-existing schemas.

### New schemas by NIP:

| NIP | Kinds Added | Description |
|-----|------------|-------------|
| NIP-34 | 1618, 1619 | Pull Request, PR Update |
| NIP-43 | 8000, 8001, 13534, 28934, 28935, 28936 | Access Management (add/remove user, membership lists, join/invite/leave) |
| NIP-54 | 818, 30819 | Wiki Merge Request, Wiki Redirect |
| NIP-85 | 30383, 30384 | Trusted Assertions (event + addressable) |
| NIP-87 | 38172, 38173 | Cashu Mint Announcement, Fedimint Announcement |
| NIP-A4 | 24 | Public Message |
| NIP-B0 | 39701 | Web Bookmarks |
| NIP-C0 | 1337 | Code Snippet |
| NKBIP-03 | 30, 31, 32, 33 | Citations (internal, web, hardcopy, prompt references) |

### New tags (21):

`c`, `merge-base`, `branch-name` (NIP-34), `member`, `claim`, `protected` (NIP-43), `nuts`, `modules`, `n` (NIP-87), `mls_proposals` (MIP-00), `accessed_on`, `author`, `published_on`, `llm`, `doi`, `page_range`, `chapter_title`, `editor`, `published_by`, `published_in`, `version` (NKBIP-03)

### Audit-driven fixes (15 commits):

All ~280 schema YAML files were audited against their canonical NIP specs. Fixes applied:

| Fix | Schemas | Issue |
|-----|---------|-------|
| **nip-87** | kind-38172, kind-38173 | `nuts`, `n`, `modules` tags changed from conditional to required per spec |
| **nip-34** | kind-1619 | Added missing uppercase `E` and `P` tags (NIP-22 threading) |
| **nip-54** | kind-818 | Added `"source"` marker requirement on `e` tag per spec |
| **nip-65** | kind-10002, tag/r | Allowed non-r tags in tag array; added `read`/`write` marker validation |
| **nip-69** | tag/network, tag/layer | Opened closed enums — spec says "etc." indicating extensible lists |
| **nip-52** | kind-31923, tag/start_tzid | Added missing required `D` tag; harmonized timezone regex |
| **nip-59** | kind-1059 | Relaxed `p` tag from required to optional (spec says SHOULD) |
| **nip-60** | kind-17375 | Removed incorrect `mint` tag — spec puts mints in encrypted content |
| **nip-62** | kind-62 | Added `ALL_RELAYS` support to relay tag |
| **nip-72** | kind-4550 | Added missing `e` tag requirement for approved post reference |
| **nip-73** | tag/k | Fixed pattern to allow `#` hashtag type; reduced maxItems to 2 |
| **nip-90** | kind-6000/6300/6301, tag/i, tag/bid | Swapped request→optional / amount→required; added input type enum; removed undocumented bid element |
| **mip-00** | kind-443 | Added missing required `mls_proposals` tag + alias |
| **nip-99** | kind-30402, kind-30403 | Added missing `d` tag (required for addressable events) |
| **nip-A0** | kind-1244 | Added NIP-22 `K` tag requirement (spec says MUST follow NIP-22) |

### Notable decisions:

- **NIP-87 kind-38173**: Uses inline `u` tag validation (not `@/tag/u.yaml`) because Fedimint invite codes are not URLs
- **NIP-54 kind-818**: Custom inline `e` tag with `"source"` marker since base `e.yaml` doesn't support NIP-54 markers
- **NIP-43**: All group control events require the `["-"]` protected tag per spec
- **NKBIP-03**: Referenced from the official NIP README; kinds 30-33 for structured academic/web/prompt citations
- **NIP-90**: Created NIP-90-specific `amount` tag allowing optional bolt11 element (NIP-57's version is too strict)

## Test plan

- [x] `pnpm build` succeeds
- [x] All 1976 tests pass (457 sample validations, 513 sample coverage, 666 structural lint, 340 error messages)
- [x] Each new kind has valid + invalid sample files
- [x] All tag aliases resolve correctly
- [ ] Verify fix commits don't break existing sample validations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added many new event kinds and tag types: pull-request events, repo/PR metadata, membership/invite flows, wiki actions, code snippets, mint/federation announcements, bookmarks, public messages, and user add/remove events.

* **Documentation**
  * Added numerous valid and invalid JSON samples illustrating the new event kinds and tag formats.

* **Chores**
  * Tightened and extended schema validations: required tag presence, conditional requirements, tag formats, array constraints, and clearer validation messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->