### PR TITLE
docs: add validator compatibility matrix + update README schema coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,10 @@ echo '$id: "https://schemata.nostr.watch/note/kind/YYYY"' > nips/nip-XX/kind-YYY
 - `kind-1618` - Git issue
 - `kind-1619` - Git repo announcement
 - `kind-1621` - Git reply
-- `kind-1630`–`kind-1633` - Git status (open/applied/closed/draft)
+- `kind-1630` - Git status open
+- `kind-1631` - Git status applied
+- `kind-1632` - Git status closed
+- `kind-1633` - Git status draft
 - `kind-30617` - Git repository
 - `kind-30618` - Git repository state
 
@@ -260,7 +263,9 @@ echo '$id: "https://schemata.nostr.watch/note/kind/YYYY"' > nips/nip-XX/kind-YYY
 - `kind-8000` - Group join
 - `kind-8001` - Group invite
 - `kind-13534` - Group member list
-- `kind-28934`–`kind-28936` - Group events
+- `kind-28934` - Group add event
+- `kind-28935` - Group remove event
+- `kind-28936` - Group event list
 
 **NIP-46** — Nostr Connect
 - `kind-24133` - Nostr Connect request/response
@@ -275,18 +280,31 @@ echo '$id: "https://schemata.nostr.watch/note/kind/YYYY"' > nips/nip-XX/kind-YYY
 **NIP-51** — Lists (27 kinds)
 - `kind-10000` - Mute list
 - `kind-10001` - Pin list
-- `kind-10003`–`kind-10007` - Bookmark, community, public chat, blocked relay, search relay lists
+- `kind-10003` - Bookmarks
+- `kind-10004` - Communities list
+- `kind-10005` - Public chats list
+- `kind-10006` - Blocked relays list
+- `kind-10007` - Search relays list
 - `kind-10009` - User groups list
-- `kind-10012`–`kind-10015` - Blocked users from relay, interest, emoji, good wiki relay lists
+- `kind-10012` - Relay feeds list
+- `kind-10015` - Interests list
 - `kind-10020` - Tagged events list
 - `kind-10030` - Custom emoji list
-- `kind-10101`–`kind-10102` - Good wiki authors/topics lists
+- `kind-10101` - Good wiki authors list
+- `kind-10102` - Good wiki relays list
 - `kind-30000` - People set
-- `kind-30002`–`kind-30007` - Relay, bookmark, curation, emoji, blocked relay sets
+- `kind-30002` - Relay sets
+- `kind-30003` - Bookmark sets
+- `kind-30004` - Curation sets
+- `kind-30005` - Video curation sets
+- `kind-30006` - Picture curation sets
+- `kind-30007` - Kind mute sets
 - `kind-30015` - Interest set
 - `kind-30030` - Custom emoji set
-- `kind-30063`–`kind-30267` - Release artifact, app-specific sets
-- `kind-39089`–`kind-39092` - Starter packs
+- `kind-30063` - Release artifact sets
+- `kind-30267` - App curation sets
+- `kind-39089` - Starter packs
+- `kind-39092` - Media starter packs
 
 **NIP-52** — Calendar events
 - `kind-31922` - Date-based calendar event
@@ -436,7 +454,10 @@ echo '$id: "https://schemata.nostr.watch/note/kind/YYYY"' > nips/nip-XX/kind-YYY
 - `kind-9` - Group chat message
 
 **NKBIP-03** — Nostr Knowledge Base
-- `kind-30`–`kind-33` - Source types (web, text, academic, AI)
+- `kind-30` - Web source
+- `kind-31` - Text source
+- `kind-32` - Academic source
+- `kind-33` - AI source
 
 **BUD-04** — Blossom auth
 - `kind-24242` - Blossom auth token

--- a/README.md
+++ b/README.md
@@ -160,76 +160,452 @@ echo '$id: "https://schemata.nostr.watch/note/kind/YYYY"' > nips/nip-XX/kind-YYY
 - 📖 **[Using Schemas](docs/usage.md)** - How to integrate schemas in your project
 - 🛠️ **[Contributing](docs/contributing.md)** - How to add new schemas
 - 🏗️ **[Architecture](docs/architecture.md)** - Technical design and build process
+- 🔍 **[Validator Compatibility](VALIDATORS.md)** - Cross-language API surface comparison
 
 ## Available Schemas
 
-<details>
-<summary>Event Kinds</summary>
+173 event kind schemas across 65 NIP/MIP directories, plus protocol messages and tags.
 
-- `kind-0` - Profile metadata (NIP-01)
-- `kind-1` - Text note (NIP-01)  
-- `kind-3` - Contact list (NIP-02)
-- `kind-6` - Repost (NIP-18)
-- `kind-16` - Generic repost (NIP-18)
-- `kind-1111` - Comment (NIP-22)
-- `kind-9802` - Highlight (NIP-84)
-- `kind-10002` - Relay list metadata (NIP-65)
-- `kind-13194` - Wallet Connect info (NIP-47)
-- `kind-23194` - Wallet Connect request (NIP-47)
-- `kind-23195` - Wallet Connect response (NIP-47)
-- `kind-23196` - Wallet Connect notification, NIP-04 (NIP-47)
-- `kind-23197` - Wallet Connect notification, NIP-44 (NIP-47)
-- `kind-24133` - Nostr Connect request/response (NIP-46)
+<details>
+<summary>Event Kinds (173 schemas)</summary>
+
+**NIP-01** — Core protocol
+- `kind-0` - Profile metadata
+- `kind-1` - Text note
+
+**NIP-02** — Contact list
+- `kind-3` - Contact list / follows
+
+**NIP-03** — OpenTimestamps
+- `kind-1040` - OpenTimestamps attestation
+
+**NIP-04** — Encrypted DMs (deprecated)
+- `kind-4` - Encrypted direct message
+
+**NIP-09** — Event deletion
+- `kind-5` - Event deletion request
+
+**NIP-17** — Private direct messages
+- `kind-14` - Chat message (rumor)
+- `kind-15` - File header
+- `kind-10050` - Relay list for DMs
+
+**NIP-18** — Reposts
+- `kind-6` - Repost
+- `kind-16` - Generic repost
+
+**NIP-22** — Comments
+- `kind-1111` - Comment
+
+**NIP-23** — Long-form content
+- `kind-30023` - Long-form article
+- `kind-30024` - Draft long-form article
+
+**NIP-25** — Reactions
+- `kind-7` - Reaction
+- `kind-17` - Reaction to website
+
+**NIP-28** — Public chat
+- `kind-40` - Create channel
+- `kind-41` - Channel metadata
+- `kind-42` - Channel message
+- `kind-43` - Hide message
+- `kind-44` - Mute user
+
+**NIP-29** — Relay-based groups
+- `kind-9000` - Group add user
+- `kind-9001` - Group remove user
+- `kind-9002` - Group edit metadata
+- `kind-9005` - Group delete event
+- `kind-9007` - Group create
+- `kind-9008` - Group delete
+- `kind-9009` - Group edit status
+- `kind-9021` - Group join request
+- `kind-9022` - Group leave request
+- `kind-39000` - Group metadata
+- `kind-39001` - Group admins
+- `kind-39002` - Group members
+- `kind-39003` - Group roles
+
+**NIP-32** — Labeling
+- `kind-1985` - Label
+
+**NIP-34** — Git stuff
+- `kind-1617` - Git patch
+- `kind-1618` - Git issue
+- `kind-1619` - Git repo announcement
+- `kind-1621` - Git reply
+- `kind-1630`–`kind-1633` - Git status (open/applied/closed/draft)
+- `kind-30617` - Git repository
+- `kind-30618` - Git repository state
+
+**NIP-35** — Torrents
+- `kind-2003` - Torrent
+- `kind-2004` - Torrent comment
+
+**NIP-37** — Drafts
+- `kind-10013` - Draft list
+- `kind-31234` - Draft
+
+**NIP-38** — User status
+- `kind-30315` - User status
+
+**NIP-39** — External identities
+- `kind-10011` - Auth identity
+
+**NIP-42** — Authentication
+- `kind-22242` - Client authentication
+
+**NIP-43** — Fast authentication (NIP proposal)
+- `kind-8000` - Group join
+- `kind-8001` - Group invite
+- `kind-13534` - Group member list
+- `kind-28934`–`kind-28936` - Group events
+
+**NIP-46** — Nostr Connect
+- `kind-24133` - Nostr Connect request/response
+
+**NIP-47** — Wallet Connect
+- `kind-13194` - Wallet Connect info
+- `kind-23194` - Wallet Connect request
+- `kind-23195` - Wallet Connect response
+- `kind-23196` - Wallet Connect notification (NIP-04)
+- `kind-23197` - Wallet Connect notification (NIP-44)
+
+**NIP-51** — Lists (27 kinds)
+- `kind-10000` - Mute list
+- `kind-10001` - Pin list
+- `kind-10003`–`kind-10007` - Bookmark, community, public chat, blocked relay, search relay lists
+- `kind-10009` - User groups list
+- `kind-10012`–`kind-10015` - Blocked users from relay, interest, emoji, good wiki relay lists
+- `kind-10020` - Tagged events list
+- `kind-10030` - Custom emoji list
+- `kind-10101`–`kind-10102` - Good wiki authors/topics lists
+- `kind-30000` - People set
+- `kind-30002`–`kind-30007` - Relay, bookmark, curation, emoji, blocked relay sets
+- `kind-30015` - Interest set
+- `kind-30030` - Custom emoji set
+- `kind-30063`–`kind-30267` - Release artifact, app-specific sets
+- `kind-39089`–`kind-39092` - Starter packs
+
+**NIP-52** — Calendar events
+- `kind-31922` - Date-based calendar event
+- `kind-31923` - Time-based calendar event
+- `kind-31924` - Calendar
+- `kind-31925` - Calendar event RSVP
+
+**NIP-53** — Live activities
+- `kind-1311` - Live chat message
+- `kind-10312` - Live participation list
+- `kind-30311` - Live event
+- `kind-30312` - Live event participant
+- `kind-30313` - Live event draft
+
+**NIP-54** — Wiki
+- `kind-818` - Merge request
+- `kind-30818` - Wiki article
+- `kind-30819` - Wiki redirect
+
+**NIP-56** — Reporting
+- `kind-1984` - Report
+
+**NIP-57** — Zaps
+- `kind-9734` - Zap request
+- `kind-9735` - Zap receipt
+
+**NIP-58** — Badges
+- `kind-8` - Badge award
+- `kind-30008` - Profile badges
+- `kind-30009` - Badge definition
+
+**NIP-59** — Gift wrap
+- `kind-13` - Seal
+- `kind-1059` - Gift wrap
+
+**NIP-5A** — Git files
+- `kind-15128` - Git file blob
+- `kind-35128` - Git file tree
+
+**NIP-60** — Cashu wallet
+- `kind-7374` - Cashu token
+- `kind-7375` - Cashu proof
+- `kind-17375` - Cashu quote
+
+**NIP-61** — Nutzaps
+- `kind-7376` - Nutzap
+- `kind-9321` - Nutzap redemption
+- `kind-10019` - Nutzap mint preferences
+
+**NIP-62** — Request discovery relays
+- `kind-62` - User discovery relay list
+
+**NIP-64** — Inline resources
+- `kind-64` - Inline resource
+
+**NIP-65** — Relay list metadata
+- `kind-10002` - Relay list metadata
+
+**NIP-66** — Relay monitoring
+- `kind-10166` - Relay monitor registration
+- `kind-30166` - Relay monitor check
+
+**NIP-68** — Picture event
+- `kind-20` - Picture
+
+**NIP-69** — Peer-to-peer trading
+- `kind-38383` - Fiat/BTC offer
+
+**NIP-71** — Video
+- `kind-21` - Short-form portrait video
+- `kind-22` - Short-form landscape video
+- `kind-34235` - Video event
+- `kind-34236` - Video view
+
+**NIP-72** — Communities
+- `kind-4550` - Community post approval
+- `kind-34550` - Community definition
+
+**NIP-75** — Zap goal
+- `kind-9041` - Zap goal
+
+**NIP-78** — Application-specific data
+- `kind-30078` - App-specific data
+
+**NIP-7D** — Threads
+- `kind-11` - Thread root
+
+**NIP-84** — Highlights
+- `kind-9802` - Highlight
+
+**NIP-85** — Trusted assertions
+- `kind-30382` - Trusted assertion
+- `kind-30383` - Trusted assertion revocation
+- `kind-30384` - Trusted assertion query
+
+**NIP-87** — Cashu mint discovery
+- `kind-38172` - Mint recommendation
+- `kind-38173` - Mint info
+
+**NIP-88** — Polls
+- `kind-1018` - Poll response
+- `kind-1068` - Poll
+
+**NIP-89** — App handlers
+- `kind-31989` - App handler recommendation
+- `kind-31990` - App handler
+
+**NIP-90** — Data vending machine
+- `kind-5000` - DVM text generation request
+- `kind-5300` - DVM text extraction request
+- `kind-5301` - DVM summarization request
+- `kind-6000` - DVM text generation result
+- `kind-6300` - DVM text extraction result
+- `kind-6301` - DVM summarization result
+- `kind-7000` - DVM job feedback
+
+**NIP-94** — File metadata
+- `kind-1063` - File metadata
+
+**NIP-96** — HTTP file storage
+- `kind-10096` - File storage server list
+
+**NIP-98** — HTTP Auth
+- `kind-27235` - HTTP authentication
+
+**NIP-99** — Classifieds
+- `kind-30402` - Classified listing
+- `kind-30403` - Draft classified listing
+
+**NIP-A0** — Coinjoin
+- `kind-1222` - Coinjoin request
+- `kind-1244` - Coinjoin proposal
+
+**NIP-A4** — Extra-metadata gift wrap
+- `kind-24` - Extra-metadata gift wrap
+
+**NIP-B0** — Reviews
+- `kind-39701` - Review
+
+**NIP-b7** — Blossom
+- `kind-10063` - Blossom server list
+
+**NIP-C0** — Audio
+- `kind-1337` - Audio event
+
+**NIP-C7** — Group chat relay
+- `kind-9` - Group chat message
+
+**NKBIP-03** — Nostr Knowledge Base
+- `kind-30`–`kind-33` - Source types (web, text, academic, AI)
+
+**BUD-04** — Blossom auth
+- `kind-24242` - Blossom auth token
+
+**MIP-00** — Marmot MLS
+- `kind-443` - MLS key package
+- `kind-10051` - MLS group list
+
+**MIP-02** — Marmot welcome
+- `kind-444` - MLS welcome message
+
+**MIP-03** — Marmot group events
+- `kind-445` - MLS group event
 
 </details>
 
 <details>
-<summary>Protocol Messages</summary>
+<summary>Protocol Messages (13 schemas)</summary>
 
-**Client to Relay:**
+**Client to Relay (NIP-01):**
 - `client-req` - Request events (REQ)
 - `client-event` - Publish event (EVENT)
 - `client-close` - Close subscription (CLOSE)
+
+**Client to Relay (NIP-42):**
 - `client-auth` - Authentication (AUTH)
 
-**Relay to Client:**
+**Client to Relay (NIP-45):**
+- `client-count` - Count events (COUNT)
+
+**Relay to Client (NIP-01):**
 - `relay-event` - Event delivery (EVENT)
 - `relay-ok` - Command result (OK)
 - `relay-eose` - End of stored events (EOSE)
 - `relay-closed` - Subscription closed (CLOSED)
 - `relay-notice` - Human-readable message (NOTICE)
+
+**Relay to Client (NIP-42):**
 - `relay-auth` - Authentication challenge (AUTH)
 
-**Other:**
+**Relay to Client (NIP-45):**
+- `relay-count` - Count result (COUNT)
+
+**Other (NIP-01):**
 - `filter` - REQ message filter object
 
 </details>
 
 <details>
-<summary>Tags</summary>
+<summary>Tags (150+ schemas)</summary>
 
-**Standard Tags:**
+**NIP-01 — Standard tags:**
 - `e` - Event reference
 - `p` - Public key reference
 - `a` - Replaceable event reference
 - `d` - Identifier for replaceable events
 - `t` - Hashtag
+- Generic tag base schema
+
+**NIP-17 — DM attachment tags:**
+- `blurhash`, `decryption-key`, `decryption-nonce`, `dim`, `encryption-algorithm`, `fallback`, `file-type`, `ox`, `relay`, `size`, `subject`, `thumb`, `x`
+
+**NIP-18 — Repost tags:**
 - `k` - Kind number reference
-- `r` - Reference/relay URL
+- `q` - Quote reference
 
-**NIP-84 Tags:**
-- `context` - Context string for highlights
-- `comment` - Quote highlight comment
+**NIP-22 — Comment tags (uppercase):**
+- `_E`, `_P`, `_A`, `_K` - Uppercase event/pubkey/address/kind references
 
-**NIP-22 Comment Tags (uppercase):**
-- `_E` - Uppercase event reference
-- `_P` - Uppercase public key reference
-- `_A` - Uppercase replaceable event reference
-- `_K` - Uppercase kind reference
+**NIP-23 — Long-form tags:**
+- `published_at`
 
-**NIP-47 Tags:**
-- `encryption` - Supported encryption method
-- `notifications` - Supported notification types
+**NIP-25 — Reaction tags:**
+- `e-react` - Reaction event reference
+- `emoji` - Custom emoji
+
+**NIP-29 — Group tags:**
+- `code` - Group code
+
+**NIP-32 — Label tags:**
+- `l` - Label
+- `L` - Label namespace
+
+**NIP-34 — Git tags:**
+- `applied-as-commits`, `branch-name`, `c`, `clone`, `commit`, `commit-pgp-sig`, `committer`, `e-root`, `e-status-reply`, `head`, `maintainers`, `merge-base`, `merge-commit`, `name`, `parent-commit`, `r-euc`, `ref`, `web`
+
+**NIP-36 — Content warnings:**
+- `content-warning`
+
+**NIP-38 — Status tags:**
+- `expiration`, `status-type`
+
+**NIP-42 — Auth tags:**
+- `challenge`, `relay`
+
+**NIP-43 — Fast auth tags:**
+- `claim`, `member`, `protected`
+
+**NIP-47 — Wallet Connect tags:**
+- `encryption`, `notifications`
+
+**NIP-51 — List tags:**
+- `group`, `word`
+
+**NIP-52 — Calendar tags:**
+- `end_tzid`, `fb`, `g`, `location`, `start_tzid`, `status`
+
+**NIP-53 — Live activity tags:**
+- `a-live`, `a-room`, `current_participants`, `endpoint`, `ends`, `hand`, `image`, `pinned`, `recording`, `relays`, `room`, `service`, `starts`, `status-live`, `status-room`, `streaming`, `summary`, `title`, `total_participants`
+
+**NIP-56 — Report tags:**
+- `e`, `p`, `server`, `x`
+
+**NIP-57 — Zap tags:**
+- `amount`, `bolt11`, `description`, `lnurl`, `preimage`
+
+**NIP-5A — Git file tags:**
+- `path`, `source`
+
+**NIP-61 — Nutzap tags:**
+- `e-redeemed`, `mint`, `proof`, `pubkey`, `relay`, `u`
+
+**NIP-65 — Relay tags:**
+- `r` - Relay URL with read/write marker
+
+**NIP-68 — Picture tags:**
+- `imeta`
+
+**NIP-69 — Trading tags:**
+- `amt`, `expires_at`, `f`, `fa`, `k`, `layer`, `network`, `pm`, `premium`, `s`, `y`, `z`
+
+**NIP-71 — Video tags:**
+- `imeta`
+
+**NIP-73 — External content IDs:**
+- `i`, `k`
+
+**NIP-84 — Highlight tags:**
+- `context`, `comment`
+
+**NIP-87 — Cashu mint tags:**
+- `modules`, `n`, `nuts`
+
+**NIP-88 — Poll tags:**
+- `endsAt`, `option`, `polltype`, `response`
+
+**NIP-89 — App handler tags:**
+- `client`
+
+**NIP-90 — DVM tags:**
+- `amount`, `bid`, `i`, `output`, `param`, `request`, `status`
+
+**NIP-94 — File metadata tags:**
+- `m`, `ox`, `url`
+
+**NIP-98 — HTTP Auth tags:**
+- `method`, `payload`
+
+**NIP-b7 — Blossom tags:**
+- `server`
+
+**NKBIP-03 — Knowledge base tags:**
+- `accessed_on`, `author`, `chapter_title`, `doi`, `editor`, `llm`, `page_range`, `published_by`, `published_in`, `published_on`, `version`
+
+**MIP-00 — Marmot tags:**
+- `client`, `encoding`, `i`, `mls_ciphersuite`, `mls_extensions`, `mls_proposals`, `mls_protocol_version`
+
+**MIP-03 — Marmot group tags:**
+- `h`
 
 </details>
 
@@ -303,6 +679,7 @@ schemata/
 | [Synvya/client](https://github.com/Synvya/client) | TypeScript | Runtime pre-publish validation of kind-0, kind-1, and kind-30402 events | Merged ([#159](https://github.com/Synvya/client/pull/159)) |
 | [applesauce](https://github.com/hzrd149/applesauce) | TypeScript | Kind-0 and kind-1 event serialization validation in CI | Merged ([#39](https://github.com/hzrd149/applesauce/pull/39)) |
 | [notedeck](https://github.com/damus-io/notedeck) | Rust | enostr::Note serialization validation in CI | PR ([#1405](https://github.com/damus-io/notedeck/pull/1405)) |
+| [nostria](https://github.com/nostria-app/nostria) | Angular/TypeScript | Schema validation tests for 34 event kinds across 16 NIPs | Merged ([#576](https://github.com/nostria-app/nostria/pull/576)) |
 | [damus](https://github.com/damus-io/damus) | Swift | NostrEvent serialization validation in CI | PR ([#3716](https://github.com/damus-io/damus/pull/3716)) |
 
 ## Contributing

--- a/VALIDATORS.md
+++ b/VALIDATORS.md
@@ -1,0 +1,80 @@
+# Validator Compatibility Matrix
+
+Cross-language API surface comparison for all `schemata-validator-*` implementations. The reference implementation is [`@nostrwatch/schemata-js-ajv`](https://github.com/sandwichfarm/nostr-watch/tree/next/libraries/schemata-js-ajv).
+
+## Core Functions
+
+| Function | JS (ref) | Rust | Kotlin | Go | Swift | Dart | Python | Java | PHP | Ruby | C# | C++ |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| `validate` | yes | yes | yes | yes | — | yes | yes | yes | yes | yes | yes | yes |
+| `validateNote` | yes | yes | yes | yes | yes | yes | yes | yes | yes | yes | yes | yes |
+| `validateNip11` | yes | yes | yes | yes | yes | yes | yes | yes | yes | yes | — | yes |
+| `validateMessage` | yes | yes | yes | yes | yes | yes | yes | yes | — | — | — | yes |
+| `getSchema` | — | yes | yes | yes | yes | yes | yes | yes | yes | yes | yes | yes |
+
+## Types
+
+| Type | JS (ref) | Rust | Kotlin | Go | Swift | Dart | Python | Java | PHP | Ruby | C# | C++ |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| `ValidationResult` | yes | yes | yes | yes | yes | yes | yes | yes (record) | yes | yes (Struct) | yes (record) | yes |
+| `ValidationError` | AJV ErrorObject | yes | yes | yes | yes | yes | yes (dataclass) | yes (record) | yes | yes (Struct) | yes (record) | yes |
+| `Subject` enum | string literal | yes | yes | yes (int) | yes | yes | yes (Enum) | yes | — | — | yes | yes |
+
+## Internal Features
+
+| Feature | JS (ref) | Rust | Kotlin | Go | Swift | Dart | Python | Java | PHP | Ruby | C# | C++ |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| Strip nested `$id` | — | yes | yes | yes | yes | yes | yes | yes | yes | yes | — | yes |
+| Strip nested `$schema` | — | — | — | — | yes | yes | — | yes | yes | yes | — | yes |
+| Additional props warnings | yes | yes | yes | yes | yes | yes | yes | — | — | — | — | — |
+| `errorMessage` enrichment | — | yes | yes | yes* | — | — | yes | — | — | — | — | — |
+
+\* Go has the code but `enrichMessage` is never called (dead code).
+
+## Input Types
+
+| Language | Schema input | Data input |
+|---|---|---|
+| JS (ref) | internal (AJV compiled) | `any` / `NostrEvent` |
+| Rust | `&serde_json::Value` | `&serde_json::Value` |
+| Kotlin | `JsonElement` (kotlinx) | `JsonElement` (kotlinx) |
+| Go | `json.RawMessage` | `json.RawMessage` |
+| Swift | `[String: Any]` | `[String: Any]` / `Any` |
+| Dart | `Map<String, dynamic>` | `dynamic` |
+| Python | `dict` | `Any` |
+| Java | `String` (JSON) | `String` (JSON) |
+| PHP | `array` | `mixed` |
+| Ruby | `Hash` | `Object` |
+| C# | `string` (JSON) | `string` (JSON) |
+| C++ | `const std::string&` (JSON) | `const std::string&` (JSON) |
+
+## JSON Schema Library & Draft
+
+| Language | Library | Draft |
+|---|---|---|
+| JS (ref) | AJV | 7 |
+| Rust | `jsonschema` 0.45 | 7 |
+| Kotlin | networknt json-schema-validator 1.5.6 | 7 |
+| Go | santhosh-tekuri/jsonschema v6 | 7 |
+| Swift | kylef/JSONSchema.swift | 7 |
+| Dart | Workiva json_schema 5.2 | 7 |
+| Python | jsonschema >=4.0 | 7 |
+| Java | networknt json-schema-validator 1.5.6 | 7 |
+| PHP | opis/json-schema 2.0 | 7 |
+| Ruby | json_schemer 2.0 | 7 |
+| C# | JsonSchema.Net 7.* | 7 |
+| C++ | valijson 1.0.3 | 7 |
+
+## Gaps
+
+| Gap | Affected repos | Severity |
+|---|---|---|
+| Missing `validateMessage` | PHP, Ruby, C# | Medium — can't validate relay/client protocol messages |
+| Missing `validateNip11` | C# | Medium — can't validate relay info documents |
+| Missing `validate` (low-level) | Swift | Low — users can't validate against arbitrary schemas |
+| No `Subject` enum | PHP, Ruby | Low — follows from missing `validateMessage` |
+| No additional-props warnings | Java, PHP, Ruby, C#, C++ | Medium — `warnings` array always empty, reduces signal |
+| No `errorMessage` enrichment | JS, Swift, Dart, Java, PHP, Ruby, C#, C++ | Low — uses default validator error strings instead |
+| Dead `enrichMessage` code | Go | Trivial — defined but never wired into `Validate()` |
+| `getSchema` missing from JS ref | JS | Intentional — JS uses internal AJV compiled schemas |
+| No nested `$id` stripping | JS, C# | Low — may cause resolution issues with certain schemas |


### PR DESCRIPTION
## Summary

### VALIDATORS.md (new)
- Cross-language API surface comparison for all 11 `schemata-validator-*` implementations vs the JS reference (`@nostrwatch/schemata-js-ajv`)
- Documents: core functions, types, internal features, input types, JSON schema libraries, and gap analysis

#### Gap highlights
- **Missing `validateMessage`**: PHP, Ruby, C#
- **Missing `validateNip11`**: C#
- **No additional-props warnings**: Java, PHP, Ruby, C#, C++
- **Dead `enrichMessage` code**: Go (defined but never called)

### README.md updates
- **Available Schemas**: expanded from 14 to 173 event kinds, grouped by NIP (reflects PRs #80, #84, #86, #90, #92, #93)
- **Protocol Messages**: added NIP-45 COUNT messages (`client-count`, `relay-count`)
- **Tags**: expanded from ~15 to 150+ tag schemas, grouped by NIP
- **Used By**: added [nostria](https://github.com/nostria-app/nostria) — 34 event kinds validated across 16 NIPs ([#576](https://github.com/nostria-app/nostria/pull/576))
- **Documentation**: linked VALIDATORS.md from docs section

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Cross-reference function availability against actual source code
- [ ] Verify Available Schemas counts match `find nips mips -name 'schema.yaml' -path '*/kind-*' | wc -l`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive cross-language validator compatibility matrix describing validator APIs, behaviors, and feature support.
  * Expanded schema listings: Event Kinds (173 schemas), Protocol Messages (13 schemas), and Tags (150+ schemas), now grouped by NIP.
  * Updated the downstream implementations list to include a new nostria entry with coverage summary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->