### PR TITLE
fix: relax tag schemas for kind:3, kind:10063, kind:10096 to allow non-primary tags

### DIFF
--- a/nips/nip-02/kind-3/samples/invalid.non-string-tag-element.json
+++ b/nips/nip-02/kind-3/samples/invalid.non-string-tag-element.json
@@ -4,8 +4,8 @@
   "created_at": 1670000000,
   "kind": 3,
   "tags": [
-    ["e", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"]
+    ["p", 12345]
   ],
-  "content": "{}",
+  "content": "",
   "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
 }

--- a/nips/nip-02/kind-3/samples/valid.with-client-tag.json
+++ b/nips/nip-02/kind-3/samples/valid.with-client-tag.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 3,
+  "tags": [
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["client", "Primal Android"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-02/kind-3/schema.yaml
+++ b/nips/nip-02/kind-3/schema.yaml
@@ -6,10 +6,9 @@ allOf:
   - $ref: "@/note.yaml"
   - type: object
     properties: 
-      tags: 
+      tags:
         type: array
-        items: 
-          $ref: "@/tag/p.yaml"
-        additionalItems: false
+        items:
+          $ref: "@/tag.yaml"
         errorMessage:
-          type: "tags must be an array of p tags and only p tags"
+          type: "tags must be an array of valid tag tuples"

--- a/nips/nip-96/kind-10096/samples/valid.with-client-tag.json
+++ b/nips/nip-96/kind-10096/samples/valid.with-client-tag.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 10096,
+  "tags": [
+    ["server", "https://files.example.com"],
+    ["client", "Snort"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nip-96/kind-10096/schema.yaml
+++ b/nips/nip-96/kind-10096/schema.yaml
@@ -11,13 +11,14 @@ allOf:
       tags:
         type: array
         items:
+          $ref: "@/tag.yaml"
+        contains:
           $ref: "@/tag/server.yaml"
-        additionalItems: false
         minItems: 1
         errorMessage:
-          type: "tags must be an array of server tags"
-          minItems: "tags must contain at least one server tag"
-          additionalItems: "file server lists must only include server tags"
+          type: "tags must be an array of valid tag tuples"
+          contains: "tags must include at least one server tag"
+          minItems: "tags array must have at least one tag"
     required:
       - kind
       - tags

--- a/nips/nip-b7/kind-10063/samples/valid.with-client-tag.json
+++ b/nips/nip-b7/kind-10063/samples/valid.with-client-tag.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 10063,
+  "tags": [
+    ["server", "https://blossom.example.com/"],
+    ["client", "Primal Android"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-b7/kind-10063/schema.yaml
+++ b/nips/nip-b7/kind-10063/schema.yaml
@@ -7,16 +7,17 @@ allOf:
       kind:
         const: 10063
         errorMessage: "kind must equal 10063"
-      tags: 
+      tags:
         type: array
-        items: 
+        items:
+          $ref: "@/tag.yaml"
+        contains:
           $ref: "@/tag/server.yaml"
-        additionalItems: false
         # Blossom lists are intended to advertise at least one reachable server.
         minItems: 1
         errorMessage:
-          type: "tags must be an array of server tags"
-          minItems: "tags array must have at least one server tag"
-          additionalItems: "server lists must only include server tags"
+          type: "tags must be an array of valid tag tuples"
+          contains: "tags must include at least one server tag"
+          minItems: "tags array must have at least one tag"
     required:
       - tags


### PR DESCRIPTION
## Summary

Relaxes three schemas that erroneously reject events containing non-primary tags (e.g. NIP-89 `["client", ...]` tags used by Primal, Snort, etc.). None of the relevant specs prohibit other tag types.

- **kind:3 (NIP-02)** — `items: @/tag/p.yaml` → `items: @/tag.yaml`
- **kind:10063 (BUD-03 Blossom)** — `items: @/tag/server.yaml` → `items: @/tag.yaml` + `contains: @/tag/server.yaml`
- **kind:10096 (NIP-96)** — `items: @/tag/server.yaml` → `items: @/tag.yaml` + `contains: @/tag/server.yaml`

For kind:10063 and kind:10096 the fix adds a `contains` constraint so at least one server tag is still required (matching the spec language "MUST include at least one server tag").

## Audit

All 173 kind schemas were audited. Only these 3 had the pitfall pattern (`items` referencing a specific tag type, forcing ALL tags to match). The remaining 170 either use permissive `items: @/tag.yaml` or have no tag constraints.

## Spec references

- **NIP-02:** "defined as having a list of p tags" — descriptive, not restrictive
- **BUD-03:** "The event MUST include at least one server tag" — presence, not exclusivity
- **NIP-96:** "Servers are listed as server tags" — descriptive, not restrictive
- **NIP-89:** "clients MAY include a client tag" on any event

Ref: nostrability/sherlock#5

## Test plan

- [x] `pnpm build` succeeds
- [x] `pnpm test` passes (2008/2008 tests, 4 test files)
- [x] Compiled schemas no longer have `const: "p"` or `const: "server"` constraints on every tag item
- [x] New `valid.with-client-tag.json` samples pass for all three kinds
- [x] Existing valid/invalid samples still pass/fail correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added sample files demonstrating client tag support across multiple event specifications
  * Updated schema validation to allow flexible tag tuples while maintaining type-specific requirements
  * Improved validation error messages for clarity and consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->