### PR TITLE
feat: add Spells + CVM schemas (8 kinds)

### DIFF
--- a/@/tag/cmd.yaml
+++ b/@/tag/cmd.yaml
@@ -1,0 +1,2 @@
+allOf: 
+  - $ref: "nips/nipless/tag/cmd/schema.yaml"

--- a/nips/nipless/kind-11316/samples/invalid.wrong-kind.json
+++ b/nips/nipless/kind-11316/samples/invalid.wrong-kind.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1,
+  "tags": [
+    ["d", "my-mcp-server"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nipless/kind-11316/samples/valid.json
+++ b/nips/nipless/kind-11316/samples/valid.json
@@ -1,0 +1,13 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 11316,
+  "tags": [
+    ["d", "my-mcp-server"],
+    ["name", "Example MCP Server"],
+    ["about", "An example CVM server announcement"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nipless/kind-11316/schema.yaml
+++ b/nips/nipless/kind-11316/schema.yaml
@@ -1,0 +1,13 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind11316
+description: "CVM Server Announcement (CEP-06)"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 11316
+        description: "Kind 11316 identifies a CVM server announcement"
+        errorMessage: "kind must equal 11316"
+    required:
+      - kind

--- a/nips/nipless/kind-11317/samples/invalid.wrong-kind.json
+++ b/nips/nipless/kind-11317/samples/invalid.wrong-kind.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1,
+  "tags": [
+    ["d", "my-mcp-server"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nipless/kind-11317/samples/valid.json
+++ b/nips/nipless/kind-11317/samples/valid.json
@@ -1,0 +1,13 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 11317,
+  "tags": [
+    ["d", "my-mcp-server"],
+    ["t", "tool:search"],
+    ["t", "tool:fetch"]
+  ],
+  "content": "{\"tools\":[{\"name\":\"search\",\"description\":\"Search the web\"}]}",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nipless/kind-11317/schema.yaml
+++ b/nips/nipless/kind-11317/schema.yaml
@@ -1,0 +1,13 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind11317
+description: "CVM Published Tools List (CEP-06)"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 11317
+        description: "Kind 11317 identifies a CVM published tools list"
+        errorMessage: "kind must equal 11317"
+    required:
+      - kind

--- a/nips/nipless/kind-11318/samples/invalid.wrong-kind.json
+++ b/nips/nipless/kind-11318/samples/invalid.wrong-kind.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1,
+  "tags": [
+    ["d", "my-mcp-server"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nipless/kind-11318/samples/valid.json
+++ b/nips/nipless/kind-11318/samples/valid.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 11318,
+  "tags": [
+    ["d", "my-mcp-server"],
+    ["t", "resource:user-profile"]
+  ],
+  "content": "{\"resources\":[{\"uri\":\"nostr://profile\",\"name\":\"User Profile\"}]}",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nipless/kind-11318/schema.yaml
+++ b/nips/nipless/kind-11318/schema.yaml
@@ -1,0 +1,13 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind11318
+description: "CVM Published Resources List (CEP-06)"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 11318
+        description: "Kind 11318 identifies a CVM published resources list"
+        errorMessage: "kind must equal 11318"
+    required:
+      - kind

--- a/nips/nipless/kind-11319/samples/invalid.wrong-kind.json
+++ b/nips/nipless/kind-11319/samples/invalid.wrong-kind.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1,
+  "tags": [
+    ["d", "my-mcp-server"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nipless/kind-11319/samples/valid.json
+++ b/nips/nipless/kind-11319/samples/valid.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 11319,
+  "tags": [
+    ["d", "my-mcp-server"],
+    ["t", "template:user-notes"]
+  ],
+  "content": "{\"resourceTemplates\":[{\"uriTemplate\":\"nostr://notes/{pubkey}\",\"name\":\"User Notes\"}]}",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nipless/kind-11319/schema.yaml
+++ b/nips/nipless/kind-11319/schema.yaml
@@ -1,0 +1,13 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind11319
+description: "CVM Published Resource Templates (CEP-06)"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 11319
+        description: "Kind 11319 identifies CVM published resource templates"
+        errorMessage: "kind must equal 11319"
+    required:
+      - kind

--- a/nips/nipless/kind-11320/samples/invalid.wrong-kind.json
+++ b/nips/nipless/kind-11320/samples/invalid.wrong-kind.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1,
+  "tags": [
+    ["d", "my-mcp-server"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nipless/kind-11320/samples/valid.json
+++ b/nips/nipless/kind-11320/samples/valid.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 11320,
+  "tags": [
+    ["d", "my-mcp-server"],
+    ["t", "prompt:summarize"]
+  ],
+  "content": "{\"prompts\":[{\"name\":\"summarize\",\"description\":\"Summarize a nostr thread\"}]}",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nipless/kind-11320/schema.yaml
+++ b/nips/nipless/kind-11320/schema.yaml
@@ -1,0 +1,13 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind11320
+description: "CVM Published Prompts List (CEP-06)"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 11320
+        description: "Kind 11320 identifies a CVM published prompts list"
+        errorMessage: "kind must equal 11320"
+    required:
+      - kind

--- a/nips/nipless/kind-25910/samples/invalid.empty-content.json
+++ b/nips/nipless/kind-25910/samples/invalid.empty-content.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 25910,
+  "tags": [
+    ["p", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nipless/kind-25910/samples/invalid.missing-p-tag.json
+++ b/nips/nipless/kind-25910/samples/invalid.missing-p-tag.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 25910,
+  "tags": [
+    ["e", "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"]
+  ],
+  "content": "{\"jsonrpc\":\"2.0\",\"method\":\"tools/list\",\"id\":1}",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nipless/kind-25910/samples/valid.json
+++ b/nips/nipless/kind-25910/samples/valid.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 25910,
+  "tags": [
+    ["p", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"]
+  ],
+  "content": "{\"jsonrpc\":\"2.0\",\"method\":\"tools/list\",\"id\":1}",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nipless/kind-25910/samples/valid.response.json
+++ b/nips/nipless/kind-25910/samples/valid.response.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+  "created_at": 1670000000,
+  "kind": 25910,
+  "tags": [
+    ["p", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"],
+    ["e", "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"]
+  ],
+  "content": "{\"jsonrpc\":\"2.0\",\"result\":{\"tools\":[]},\"id\":1}",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nipless/kind-25910/schema.yaml
+++ b/nips/nipless/kind-25910/schema.yaml
@@ -1,0 +1,33 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind25910
+description: "CVM/MCP Transport — JSON-RPC over Nostr (CEP-01)"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 25910
+        description: "Kind 25910 identifies an MCP JSON-RPC transport message"
+        errorMessage: "kind must equal 25910"
+      content:
+        type: string
+        minLength: 1
+        description: "JSON-RPC message (request or response)"
+        errorMessage:
+          minLength: "content must be a non-empty string containing a JSON-RPC message"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        errorMessage:
+          minItems: "tags must contain at least one tag"
+        allOf:
+          - contains:
+              $ref: "@/tag/p.yaml"
+            errorMessage:
+              contains: "tags must include a p tag identifying the recipient"
+    required:
+      - kind
+      - content
+      - tags

--- a/nips/nipless/kind-30777/samples/invalid.missing-d-tag.json
+++ b/nips/nipless/kind-30777/samples/invalid.missing-d-tag.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 30777,
+  "tags": [
+    ["a", "777:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:latest-notes"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nipless/kind-30777/samples/valid.json
+++ b/nips/nipless/kind-30777/samples/valid.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 30777,
+  "tags": [
+    ["d", "my-spellbook"],
+    ["a", "777:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:latest-notes"]
+  ],
+  "content": "",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nipless/kind-30777/schema.yaml
+++ b/nips/nipless/kind-30777/schema.yaml
@@ -1,0 +1,22 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind30777
+description: "Spellbook — collection of spells (addressable event)"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 30777
+        errorMessage: "kind must equal 30777"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        allOf:
+          - contains:
+              $ref: "@/tag/d.yaml"
+            errorMessage:
+              contains: "tags must include a d tag (required for addressable events)"
+    required:
+      - kind
+      - tags

--- a/nips/nipless/kind-777/samples/invalid.missing-cmd.json
+++ b/nips/nipless/kind-777/samples/invalid.missing-cmd.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 777,
+  "tags": [
+    ["k", "1"],
+    ["limit", "50"]
+  ],
+  "content": "Missing cmd tag",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nipless/kind-777/samples/invalid.no-filter-tags.json
+++ b/nips/nipless/kind-777/samples/invalid.no-filter-tags.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 777,
+  "tags": [
+    ["cmd", "REQ"],
+    ["name", "my-spell"]
+  ],
+  "content": "Has cmd but no filter tags",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nipless/kind-777/samples/valid.json
+++ b/nips/nipless/kind-777/samples/valid.json
@@ -1,0 +1,14 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 777,
+  "tags": [
+    ["cmd", "REQ"],
+    ["k", "1"],
+    ["authors", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"],
+    ["limit", "50"]
+  ],
+  "content": "Latest notes from me",
+  "sig": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/nips/nipless/kind-777/schema.yaml
+++ b/nips/nipless/kind-777/schema.yaml
@@ -10,7 +10,7 @@ allOf:
         errorMessage: "kind must equal 777"
       content:
         type: string
-        description: "Optional human-readable description of the spell"
+        description: "Human-readable description of the spell"
       tags:
         type: array
         items:

--- a/nips/nipless/kind-777/schema.yaml
+++ b/nips/nipless/kind-777/schema.yaml
@@ -1,0 +1,70 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind777
+description: "Spell — portable REQ filter (Grimoire/nak)"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 777
+        errorMessage: "kind must equal 777"
+      content:
+        type: string
+        description: "Optional human-readable description of the spell"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 2
+        allOf:
+          - contains:
+              $ref: "@/tag/cmd.yaml"
+            errorMessage:
+              contains: "tags must include a cmd tag with value REQ or COUNT"
+          - anyOf:
+              - contains:
+                  type: array
+                  minItems: 2
+                  items:
+                    - const: "k"
+              - contains:
+                  type: array
+                  minItems: 2
+                  items:
+                    - const: "authors"
+              - contains:
+                  type: array
+                  minItems: 2
+                  items:
+                    - const: "ids"
+              - contains:
+                  type: array
+                  minItems: 2
+                  items:
+                    - const: "tag"
+              - contains:
+                  type: array
+                  minItems: 2
+                  items:
+                    - const: "limit"
+              - contains:
+                  type: array
+                  minItems: 2
+                  items:
+                    - const: "since"
+              - contains:
+                  type: array
+                  minItems: 2
+                  items:
+                    - const: "until"
+              - contains:
+                  type: array
+                  minItems: 2
+                  items:
+                    - const: "search"
+            errorMessage:
+              anyOf: "tags must include at least one filter tag (k, authors, ids, tag, limit, since, until, or search)"
+    required:
+      - kind
+      - content
+      - tags

--- a/nips/nipless/tag/cmd/schema.yaml
+++ b/nips/nipless/tag/cmd/schema.yaml
@@ -1,0 +1,13 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      - const: "cmd"
+      - type: string
+        enum: ["REQ", "COUNT"]
+    additionalItems: false
+    errorMessage:
+      minItems: "cmd tag must have at least 2 elements"


### PR DESCRIPTION
## Summary
- **Spells** (kinds 777, 30777): Portable REQ filters used by Grimoire and nak v0.19.1+. Kind 777 validates cmd tag (`REQ`/`COUNT`) and at least one filter tag (k, authors, ids, tag, limit, since, until, search). Kind 30777 is the addressable spellbook collection.
- **CVM/ContextVM** (kinds 25910, 11316-11320): MCP JSON-RPC transport over Nostr (CEP-01/CEP-06). Kind 25910 validates non-empty JSON-RPC content and a p tag recipient. Kinds 11316-11320 are minimal discovery schemas for server announcements, tools, resources, resource templates, and prompts lists.
- **New tag**: `cmd` tag schema (`["cmd", "REQ"|"COUNT"]`) with alias.

All 8 schemas go under `nips/nipless/` (no assigned NIP number). 29 files total: 9 schemas, 21 samples (valid + invalid).

## Test plan
- [x] `pnpm build` — all YAML→JSON compilation succeeds, refs fully dereferenced
- [x] `pnpm test` — 2092 tests pass (487 samples, 360 error messages, 543 coverage, 702 structural lint)
- [x] Valid samples pass, invalid samples fail with expected error messages
- [x] Compiled JSON verified: correct `$id` generation, `$ref` dereferencing, errorMessage placement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for new event types including CVM Server Announcement, CVM Published Resources Lists, CVM Published Prompts Lists, and CVM/MCP Transport messaging capabilities with validation schemas.

* **Documentation**
  * Included comprehensive validation schemas and sample valid/invalid examples for all newly supported event types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->