### PR TITLE
Add C ecosystem to data packages and validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Data packages vendor the compiled JSON schemas and provide a registry lookup for
 | C#/.NET | [`schemata-csharp`](https://github.com/nostrability/schemata-csharp) | `Schemata.Get("kind1Schema")` |
 | C++ | [`schemata-cpp`](https://github.com/nostrability/schemata-cpp) | `schemata::get("kind1Schema")` |
 | Ruby | [`schemata-ruby`](https://github.com/nostrability/schemata-ruby) | `SchemataNostr.get('kind1Schema')` |
+| C | [`schemata-c`](https://github.com/nostrability/schemata-c) | `schemata_get("kind1Schema")` |
 
 > **Note:** Swift uses a single-package approach (schemas inlined into the validator) because SPM resource bundles cause iOS codesign failures. See [#88](https://github.com/nostrability/schemata/issues/88) for details on how this applies to future Kotlin Multiplatform support.
 
@@ -76,6 +77,7 @@ Validators wrap a JSON Schema library and the data package to provide nostr-spec
 | C#/.NET | [`schemata-validator-csharp`](https://github.com/nostrability/schemata-validator-csharp) | [JsonSchema.Net](https://github.com/gregsdennis/json-everything) |
 | C++ | [`schemata-validator-cpp`](https://github.com/nostrability/schemata-validator-cpp) | [valijson](https://github.com/tristanpenman/valijson) |
 | Ruby | [`schemata-validator-ruby`](https://github.com/nostrability/schemata-validator-ruby) | [json_schemer](https://github.com/davishmcclurg/json_schemer) |
+| C | [`schemata-validator-c`](https://github.com/nostrability/schemata-validator-c) | [jsonc-daccord](https://github.com/nostrability/jsonc-daccord) (nostrability fork) |
 
 ## Adding new Schemas
 `@nostrability/schemata` assumes a kind is associated to a NIP and so the schemas are organized by NIP. The system has `aliases` that are generated via the build-script. The aliases make it easier to reference commonly reused schemas (such as tags, and base schemata like `note`). 

--- a/VALIDATORS.md
+++ b/VALIDATORS.md
@@ -4,30 +4,30 @@ Cross-language API surface comparison for all `schemata-validator-*` implementat
 
 ## Core Functions
 
-| Function | JS (ref) | Rust | Kotlin | Go | Swift | Dart | Python | Java | PHP | Ruby | C# | C++ |
-|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| `validate` | yes | yes | yes | yes | — | yes | yes | yes | yes | yes | yes | yes |
-| `validateNote` | yes | yes | yes | yes | yes | yes | yes | yes | yes | yes | yes | yes |
-| `validateNip11` | yes | yes | yes | yes | yes | yes | yes | yes | yes | yes | — | yes |
-| `validateMessage` | yes | yes | yes | yes | yes | yes | yes | yes | — | — | — | yes |
-| `getSchema` | — | yes | yes | yes | yes | yes | yes | yes | yes | yes | yes | yes |
+| Function | JS (ref) | Rust | Kotlin | Go | Swift | Dart | Python | Java | PHP | Ruby | C# | C++ | C |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| `validate` | yes | yes | yes | yes | — | yes | yes | yes | yes | yes | yes | yes | yes |
+| `validateNote` | yes | yes | yes | yes | yes | yes | yes | yes | yes | yes | yes | yes | yes |
+| `validateNip11` | yes | yes | yes | yes | yes | yes | yes | yes | yes | yes | — | yes | yes |
+| `validateMessage` | yes | yes | yes | yes | yes | yes | yes | yes | — | — | — | yes | yes |
+| `getSchema` | — | yes | yes | yes | yes | yes | yes | yes | yes | yes | yes | yes | yes |
 
 ## Types
 
-| Type | JS (ref) | Rust | Kotlin | Go | Swift | Dart | Python | Java | PHP | Ruby | C# | C++ |
-|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| `ValidationResult` | yes | yes | yes | yes | yes | yes | yes | yes (record) | yes | yes (Struct) | yes (record) | yes |
-| `ValidationError` | AJV ErrorObject | yes | yes | yes | yes | yes | yes (dataclass) | yes (record) | yes | yes (Struct) | yes (record) | yes |
-| `Subject` enum | string literal | yes | yes | yes (int) | yes | yes | yes (Enum) | yes | — | — | yes | yes |
+| Type | JS (ref) | Rust | Kotlin | Go | Swift | Dart | Python | Java | PHP | Ruby | C# | C++ | C |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| `ValidationResult` | yes | yes | yes | yes | yes | yes | yes | yes (record) | yes | yes (Struct) | yes (record) | yes | yes (struct) |
+| `ValidationError` | AJV ErrorObject | yes | yes | yes | yes | yes | yes (dataclass) | yes (record) | yes | yes (Struct) | yes (record) | yes | yes (struct) |
+| `Subject` enum | string literal | yes | yes | yes (int) | yes | yes | yes (Enum) | yes | — | — | yes | yes | yes (enum) |
 
 ## Internal Features
 
-| Feature | JS (ref) | Rust | Kotlin | Go | Swift | Dart | Python | Java | PHP | Ruby | C# | C++ |
-|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| Strip nested `$id` | — | yes | yes | yes | yes | yes | yes | yes | yes | yes | — | yes |
-| Strip nested `$schema` | — | — | — | — | yes | yes | — | yes | yes | yes | — | yes |
-| Additional props warnings | yes | yes | yes | yes | yes | yes | yes | — | — | — | — | — |
-| `errorMessage` enrichment | — | yes | yes | yes* | — | — | yes | — | — | — | — | — |
+| Feature | JS (ref) | Rust | Kotlin | Go | Swift | Dart | Python | Java | PHP | Ruby | C# | C++ | C |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| Strip nested `$id` | — | yes | yes | yes | yes | yes | yes | yes | yes | yes | — | yes | yes |
+| Strip nested `$schema` | — | — | — | — | yes | yes | — | yes | yes | yes | — | yes | yes |
+| Additional props warnings | yes | yes | yes | yes | yes | yes | yes | — | — | — | — | — | yes |
+| `errorMessage` enrichment | — | yes | yes | yes* | — | — | yes | — | — | — | — | — | yes |
 
 \* Go has the code but `enrichMessage` is never called (dead code).
 
@@ -47,6 +47,7 @@ Cross-language API surface comparison for all `schemata-validator-*` implementat
 | Ruby | `Hash` | `Object` |
 | C# | `string` (JSON) | `string` (JSON) |
 | C++ | `const std::string&` (JSON) | `const std::string&` (JSON) |
+| C | `const char*` (JSON) | `const char*` (JSON) |
 
 ## JSON Schema Library & Draft
 
@@ -64,6 +65,7 @@ Cross-language API surface comparison for all `schemata-validator-*` implementat
 | Ruby | json_schemer 2.0 | 7 |
 | C# | JsonSchema.Net 7.* | 7 |
 | C++ | valijson 1.0.3 | 7 |
+| C | jsonc-daccord (nostrability fork) | 7 |
 
 ## Gaps
 


### PR DESCRIPTION
## Summary
- Add `schemata-c` to the Data Packages table in README
- Add `schemata-validator-c` + `jsonc-daccord` to the Validators table in README
- Add C column to all VALIDATORS.md comparison tables (full coverage, no new gaps)

## Test plan
- [ ] Verify table rendering in README
- [ ] Verify VALIDATORS.md tables are aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)