### PR TITLE
fix: mark JS errorMessage enrichment as supported

### DIFF
--- a/VALIDATORS.md
+++ b/VALIDATORS.md
@@ -27,7 +27,7 @@ Cross-language API surface comparison for all `schemata-validator-*` implementat
 | Strip nested `$id` | — | yes | yes | yes | yes | yes | yes | yes | yes | yes | — | yes | yes |
 | Strip nested `$schema` | — | — | — | — | yes | yes | — | yes | yes | yes | — | yes | yes |
 | Additional props warnings | yes | yes | yes | yes | yes | yes | yes | — | — | — | — | — | yes |
-| `errorMessage` enrichment | — | yes | yes | yes* | — | — | yes | — | — | — | — | — | yes |
+| `errorMessage` enrichment | yes | yes | yes | yes* | — | — | yes | — | — | — | — | — | yes |
 
 \* Go has the code but `enrichMessage` is never called (dead code).
 
@@ -76,7 +76,7 @@ Cross-language API surface comparison for all `schemata-validator-*` implementat
 | Missing `validate` (low-level) | Swift | Low — users can't validate against arbitrary schemas |
 | No `Subject` enum | PHP, Ruby | Low — follows from missing `validateMessage` |
 | No additional-props warnings | Java, PHP, Ruby, C#, C++ | Medium — `warnings` array always empty, reduces signal |
-| No `errorMessage` enrichment | JS, Swift, Dart, Java, PHP, Ruby, C#, C++ | Low — uses default validator error strings instead |
+| No `errorMessage` enrichment | Swift, Dart, Java, PHP, Ruby, C#, C++ | Low — uses default validator error strings instead |
 | Dead `enrichMessage` code | Go | Trivial — defined but never wired into `Validate()` |
 | `getSchema` missing from JS ref | JS | Intentional — JS uses internal AJV compiled schemas |
 | No nested `$id` stripping | JS, C# | Low — may cause resolution issues with certain schemas |


### PR DESCRIPTION
## Summary
- AJV natively supports `errorMessage` via the `ajv-errors` plugin — it's the canonical implementation
- VALIDATORS.md incorrectly showed "—" for JS in the enrichment row
- Removed JS from the "No errorMessage enrichment" gap list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the compatibility matrix to reflect that errorMessage enrichment support is now available for JavaScript, improving feature parity across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->