### PR TITLE
fix: allow p tag without report type in kind 1984

### DIFF
--- a/nips/nip-56/kind-1984/samples/invalid-missing-p.json
+++ b/nips/nip-56/kind-1984/samples/invalid-missing-p.json
@@ -7,6 +7,6 @@
     ["e", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "illegal"]
   ],
   "content": "",
-  "sig": "deadbeef"
+  "sig": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
 }
 

--- a/nips/nip-56/kind-1984/samples/valid-impersonation-report.json
+++ b/nips/nip-56/kind-1984/samples/valid-impersonation-report.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1736800000,
+  "kind": 1984,
+  "tags": [
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "impersonation"]
+  ],
+  "content": "Profile is impersonating nostr:npub1...",
+  "sig": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-56/kind-1984/samples/valid-malware-blob-report.json
+++ b/nips/nip-56/kind-1984/samples/valid-malware-blob-report.json
@@ -1,0 +1,14 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1736800000,
+  "kind": 1984,
+  "tags": [
+    ["x", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "malware"],
+    ["e", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", "malware"],
+    ["p", "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"],
+    ["server", "https://example.com/path-to-blob.ext"]
+  ],
+  "content": "",
+  "sig": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-56/kind-1984/samples/valid-note-report.json
+++ b/nips/nip-56/kind-1984/samples/valid-note-report.json
@@ -4,9 +4,9 @@
   "created_at": 1736800000,
   "kind": 1984,
   "tags": [
-    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"]
+    ["e", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "illegal"],
+    ["p", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"]
   ],
-  "content": "",
+  "content": "He's insulting the king!",
   "sig": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
 }
-

--- a/nips/nip-56/kind-1984/schema.yaml
+++ b/nips/nip-56/kind-1984/schema.yaml
@@ -11,8 +11,11 @@ allOf:
         type: array
         allOf:
           # MUST include a p tag referencing the reported user's pubkey
+          # NIP-56: when reporting a note, the p tag just references the author (no report type needed)
           - contains:
-              $ref: "@/tag/nip-56_p.yaml"
+              anyOf:
+                - $ref: "@/tag/p.yaml"
+                - $ref: "@/tag/nip-56_p.yaml"
             errorMessage:
               contains: "tags must include a p tag referencing the reported user"
           # MUST include at least one report tag (p/e/x) with a report type as the 3rd item


### PR DESCRIPTION
## Summary
- Relaxes the kind-1984 `p` tag constraint to match NIP-56 semantics: when reporting a **note**, the `p` tag just references the author and does not need a report-type enum
- The first `contains` now uses `anyOf` between `p.yaml` (plain p tag) and `nip-56_p.yaml` (report p tag), preserving arity constraints via `additionalItems: false`
- The second `contains` (must have at least one report tag with type) is unchanged
- Fixes invalid sample signatures (`deadbeef` → valid 128-char hex) so negative samples actually test tag constraints, not sig pattern
- Adds sample events motivated by all four NIP-56 spec examples: profile nudity report, note illegality report, impersonation report, and malware blob report

Closes #107

## Test plan
- [x] `valid.json` — profile report `["p", pubkey, "nudity"]` (NIP-56 example 1)
- [x] `valid-note-report.json` — note report `["e", id, "illegal"], ["p", pubkey]` (NIP-56 example 2)
- [x] `valid-impersonation-report.json` — impersonation `["p", pubkey, "impersonation"]` (NIP-56 example 3)
- [x] `valid-malware-blob-report.json` — malware blob `["x", hash, "malware"], ["e", id, "malware"]` (NIP-56 example 4)
- [x] `invalid-missing-p.json` — fails on first contains (no p tag)
- [x] `invalid-no-report-type.json` — fails on second contains (no report tag with type)
- [x] Overlong `["p", pubkey, "relay", "extra"]` rejected (neither p.yaml nor nip-56_p.yaml match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)