### PR TITLE
fix: use NIP-88 specific e tag for kind 1018

### DIFF
--- a/@/tag/nip-88_e.yaml
+++ b/@/tag/nip-88_e.yaml
@@ -1,0 +1,2 @@
+allOf:
+  - $ref: "nips/nip-88/tag/e/schema.yaml"

--- a/nips/nip-88/kind-1018/samples/invalid-marker-e-tag.json
+++ b/nips/nip-88/kind-1018/samples/invalid-marker-e-tag.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1018,
+  "tags": [
+    ["e", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "wss://relay.example.com", "reply"],
+    ["response", "opt1"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-88/kind-1018/samples/valid-empty-relay-pubkey.json
+++ b/nips/nip-88/kind-1018/samples/valid-empty-relay-pubkey.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1018,
+  "tags": [
+    ["e", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"],
+    ["response", "opt1"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-88/kind-1018/samples/valid-relay-pubkey.json
+++ b/nips/nip-88/kind-1018/samples/valid-relay-pubkey.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1018,
+  "tags": [
+    ["e", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "wss://relay.example.com", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"],
+    ["response", "opt1"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-88/kind-1018/samples/valid-relay.json
+++ b/nips/nip-88/kind-1018/samples/valid-relay.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1018,
+  "tags": [
+    ["e", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "wss://relay.example.com"],
+    ["response", "opt1"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-88/kind-1018/schema.yaml
+++ b/nips/nip-88/kind-1018/schema.yaml
@@ -13,7 +13,7 @@ allOf:
           $ref: "@/tag/response.yaml"
         allOf:
           - contains:
-              $ref: "@/tag/e.yaml"
+              $ref: "@/tag/nip-88_e.yaml"
             errorMessage:
               contains: "response events must reference a poll event via an e tag"
         items:
@@ -27,7 +27,7 @@ allOf:
                 items:
                   - const: "e"
               then:
-                $ref: "@/tag/e.yaml"
+                $ref: "@/tag/nip-88_e.yaml"
         errorMessage:
           contains: "response events must include at least one response tag"
     required:

--- a/nips/nip-88/tag/e/schema.yaml
+++ b/nips/nip-88/tag/e/schema.yaml
@@ -1,8 +1,10 @@
 $schema: "http://json-schema.org/draft-07/schema#"
+title: "NIP-88 e tag"
 allOf:
   - $ref: "@/tag.yaml"
   - type: array
     minItems: 2
+    maxItems: 4
     items:
       - const: "e"
       - type: string

--- a/nips/nip-88/tag/e/schema.yaml
+++ b/nips/nip-88/tag/e/schema.yaml
@@ -1,0 +1,16 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+allOf:
+  - $ref: "@/tag.yaml"
+  - type: array
+    minItems: 2
+    items:
+      - const: "e"
+      - type: string
+        pattern: '^[a-f0-9]{64}$'
+      - anyOf:
+          - type: string
+            pattern: '^(ws://|wss://).+$'
+          - type: string
+            const: ""
+      - $ref: "@/secp256k1.yaml"
+    additionalItems: false


### PR DESCRIPTION
## Summary
- Creates `nips/nip-88/tag/e/schema.yaml` — an e tag schema that accepts `["e", id]`, `["e", id, relay]`, and `["e", id, relay, pubkey]` without NIP-10 marker enforcement
- Adds `@/tag/nip-88_e.yaml` alias
- Updates kind-1018 schema to use `nip-88_e` instead of the global `e` tag (both in `contains` and per-item `if/then`)
- Adds `valid-relay-pubkey.json` sample for the Jumble-style `["e", id, relay, pubkey]` pattern

NIP-88 specifies simple e tag references for poll responses without NIP-10 threading semantics. The global e tag schema enforces marker enums (`reply`/`root`) at position [3] for 4+ element tags, which rejects the common markerless `["e", id, relay, pubkey]` form.

Closes #108

## Test plan
- [x] `valid.json` — bare `["e", id]` passes
- [x] `valid-relay-pubkey.json` — `["e", id, relay, pubkey]` passes (previously rejected)
- [x] `invalid.missing-response.json` — fails on missing response tag (not sig)
- [x] 5-element e tag rejected by `additionalItems: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive validation rules for NIP-88 e-tags with support for relay URL format enforcement and secp256k1 cryptographic signature validation.
  * Introduced a new sample Kind 1018 event configuration file demonstrating proper relay pubkey settings with structured multi-element tags and response tag handling.
  * Updated the Kind 1018 schema validation framework to properly enforce and reference the newly defined e-tag structural specifications and constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->