### PR TITLE
fix: remove unnecessary typescript peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,5 @@
     "test:watch": "vitest",
     "docs": "typedoc",
     "validate": "bash scripts/validate-kind.sh"
-  },
-  "peerDependencies": {
-    "typescript": "^4.5.2"
   }
 }


### PR DESCRIPTION
## Summary

- Remove `peerDependencies: { "typescript": "^4.5.2" }` from package.json

## Why

This package ships **pre-built JS bundles and JSON schemas** — consumers never compile TypeScript source from it. The peer dependency on `typescript@^4.5.2` forces every consumer using TypeScript 5.x to work around an `ERESOLVE` conflict:

```
npm error Could not resolve dependency:
npm error peer typescript@"^4.5.2" from @nostrability/schemata@0.2.9
```

**Affected consumers** (all use TypeScript 5.x):
- [CodyTseng/jumble](https://github.com/CodyTseng/jumble/pull/689#issuecomment-3624251340) — `typescript: ~5.6.2`
- [nostria-app/nostria](https://github.com/nostria-app/nostria) — `typescript: ~5.5.x`
- [sandwichfarm/nostr-watch](https://github.com/sandwichfarm/nostr-watch) — `typescript: ^5.6.3` / `^5.7.2`

TypeScript remains in `devDependencies` for schemata's own build toolchain (typedoc, ts-loader).

## What doesn't change

- Build pipeline (YAML → JSON → esbuild, no tsc involved)
- Published artifacts (dist/bundle/schemas.js, dist/nips/**/*.json, .d.ts stubs)
- devDependencies (typescript stays for local development)

🤖 Generated with [Claude Code](https://claude.com/claude-code)