### PR TITLE
Add NIP sample coverage across 25 NIPs

### DIFF
--- a/nips/nip-01/kind-0/samples/valid-rich-profile.json
+++ b/nips/nip-01/kind-0/samples/valid-rich-profile.json
@@ -1,0 +1,9 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 0,
+  "tags": [],
+  "content": "{\"name\":\"alice\",\"about\":\"Building on nostr since 2022\",\"picture\":\"https://example.com/avatar.png\",\"display_name\":\"Alice von Nostr\",\"website\":\"https://alice.example.com\",\"banner\":\"https://example.com/banner.png\",\"bot\":false,\"lud06\":\"lnurl1dp68gurn8ghj7um9wfmxjcm99e3k7mf0v9cxj0m385ekvcenxc6r2c35xvukxefcv5mkvv34x5ekzd3ev56nyd3hxqurzepexejxxepnxscrvwfnv9nxzcn9xq6xyefhvgcxxcmyxymnserxfq5fns\",\"lud16\":\"alice@getalby.com\",\"nip05\":\"alice@example.com\"}",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-01/kind-1/samples/valid-reply-threading.json
+++ b/nips/nip-01/kind-1/samples/valid-reply-threading.json
@@ -1,0 +1,13 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1,
+  "tags": [
+    ["e", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "wss://relay.example.com", "root"],
+    ["e", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", "wss://relay.example.com", "reply"],
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"]
+  ],
+  "content": "I agree with this thread!",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-02/kind-3/samples/valid.multi-follow.json
+++ b/nips/nip-02/kind-3/samples/valid.multi-follow.json
@@ -1,0 +1,15 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 3,
+  "tags": [
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "alice"],
+    ["p", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", "bob"],
+    ["p", "1111111111111111111111111111111111111111111111111111111111111111", "carol"],
+    ["p", "2222222222222222222222222222222222222222222222222222222222222222"],
+    ["p", "3333333333333333333333333333333333333333333333333333333333333333", "eve"]
+  ],
+  "content": "{\"wss://relay.damus.io\":{\"read\":true,\"write\":true},\"wss://nos.lol\":{\"read\":true,\"write\":false},\"wss://relay.nostr.band\":{\"read\":true,\"write\":true}}",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-09/kind-5/samples/invalid.empty-tags.json
+++ b/nips/nip-09/kind-5/samples/invalid.empty-tags.json
@@ -1,0 +1,9 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 5,
+  "tags": [],
+  "content": "delete request",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-09/kind-5/samples/invalid.wrong-kind.json
+++ b/nips/nip-09/kind-5/samples/invalid.wrong-kind.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1,
+  "tags": [
+    ["e", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"]
+  ],
+  "content": "delete request",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-09/kind-5/samples/valid.a-tag-replaceable.json
+++ b/nips/nip-09/kind-5/samples/valid.a-tag-replaceable.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 5,
+  "tags": [
+    ["a", "30023:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:my-article"],
+    ["k", "30023"]
+  ],
+  "content": "removing outdated article",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-09/kind-5/samples/valid.empty-content.json
+++ b/nips/nip-09/kind-5/samples/valid.empty-content.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 5,
+  "tags": [
+    ["e", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-09/kind-5/samples/valid.mixed-e-and-a-tags.json
+++ b/nips/nip-09/kind-5/samples/valid.mixed-e-and-a-tags.json
@@ -1,0 +1,15 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 5,
+  "tags": [
+    ["e", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["e", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"],
+    ["a", "30023:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:my-article"],
+    ["k", "1"],
+    ["k", "30023"]
+  ],
+  "content": "these posts were published by accident",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-09/kind-5/samples/valid.multiple-e-tags.json
+++ b/nips/nip-09/kind-5/samples/valid.multiple-e-tags.json
@@ -1,0 +1,13 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 5,
+  "tags": [
+    ["e", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["e", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"],
+    ["k", "1"]
+  ],
+  "content": "these posts were published by accident",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-17/kind-14/samples/valid.multi-recipient.json
+++ b/nips/nip-17/kind-14/samples/valid.multi-recipient.json
@@ -1,0 +1,13 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1700000000,
+  "kind": 14,
+  "tags": [
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["p", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"],
+    ["p", "1111111111111111111111111111111111111111111111111111111111111111"],
+    ["subject", "Group planning"]
+  ],
+  "content": "Hey everyone, let us coordinate on the relay implementation."
+}

--- a/nips/nip-17/kind-14/samples/valid.reply.json
+++ b/nips/nip-17/kind-14/samples/valid.reply.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1700000000,
+  "kind": 14,
+  "tags": [
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["e", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", "wss://relay.example.com"]
+  ],
+  "content": "Thanks for the recommendation, I will check it out!"
+}

--- a/nips/nip-17/kind-14/samples/valid.with-subject.json
+++ b/nips/nip-17/kind-14/samples/valid.with-subject.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1700000000,
+  "kind": 14,
+  "tags": [
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["subject", "Nostr Development Meetup"]
+  ],
+  "content": "Are you coming to the meetup next week?"
+}

--- a/nips/nip-18/kind-16/samples/valid-replaceable-repost.json
+++ b/nips/nip-18/kind-16/samples/valid-replaceable-repost.json
@@ -1,0 +1,14 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 16,
+  "tags": [
+    ["e", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "wss://relay.example.com"],
+    ["a", "30023:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:my-article"],
+    ["k", "30023"],
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-22/kind-1111/samples/valid-blog-comment.json
+++ b/nips/nip-22/kind-1111/samples/valid-blog-comment.json
@@ -1,0 +1,17 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1111,
+  "tags": [
+    ["A", "30023:3c9849383bdea883b0bd16fece1ed36d37e37cdde3ce43b17ea4e9192ec11289:f9347ca7", "wss://example.relay"],
+    ["K", "30023"],
+    ["P", "3c9849383bdea883b0bd16fece1ed36d37e37cdde3ce43b17ea4e9192ec11289", "wss://example.relay"],
+    ["a", "30023:3c9849383bdea883b0bd16fece1ed36d37e37cdde3ce43b17ea4e9192ec11289:f9347ca7", "wss://example.relay"],
+    ["e", "5b4fc7fed15672fefe65d2426f67197b71ccc82aa0cc8a9e94f683eb78e07651", "wss://example.relay"],
+    ["k", "30023"],
+    ["p", "3c9849383bdea883b0bd16fece1ed36d37e37cdde3ce43b17ea4e9192ec11289", "wss://example.relay"]
+  ],
+  "content": "Great blog post!",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-22/kind-1111/samples/valid-file-comment.json
+++ b/nips/nip-22/kind-1111/samples/valid-file-comment.json
@@ -1,0 +1,16 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1111,
+  "tags": [
+    ["E", "768ac8720cdeb59227cf95e98b66560ef03d8bc9a90d721779e76e68fb42f5e6", "wss://example.relay", "3721e07b079525289877c366ccab47112bdff3d1b44758ca333feb2dbbbbe5bb"],
+    ["K", "1063"],
+    ["P", "3721e07b079525289877c366ccab47112bdff3d1b44758ca333feb2dbbbbe5bb"],
+    ["e", "768ac8720cdeb59227cf95e98b66560ef03d8bc9a90d721779e76e68fb42f5e6", "wss://example.relay", "3721e07b079525289877c366ccab47112bdff3d1b44758ca333feb2dbbbbe5bb"],
+    ["k", "1063"],
+    ["p", "3721e07b079525289877c366ccab47112bdff3d1b44758ca333feb2dbbbbe5bb"]
+  ],
+  "content": "Great file!",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-22/kind-1111/samples/valid-podcast-comment.json
+++ b/nips/nip-22/kind-1111/samples/valid-podcast-comment.json
@@ -1,0 +1,14 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1111,
+  "tags": [
+    ["I", "podcast:item:guid:d98d189b-dc7b-45b1-8720-d4b98690f31f", "https://fountain.fm/episode/z1y9TMQRuqXl2awyrQxg"],
+    ["K", "podcast:item:guid"],
+    ["i", "podcast:item:guid:d98d189b-dc7b-45b1-8720-d4b98690f31f", "https://fountain.fm/episode/z1y9TMQRuqXl2awyrQxg"],
+    ["k", "podcast:item:guid"]
+  ],
+  "content": "This was a great episode!",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-22/kind-1111/samples/valid-podcast-reply.json
+++ b/nips/nip-22/kind-1111/samples/valid-podcast-reply.json
@@ -1,0 +1,15 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1111,
+  "tags": [
+    ["I", "podcast:item:guid:d98d189b-dc7b-45b1-8720-d4b98690f31f", "https://fountain.fm/episode/z1y9TMQRuqXl2awyrQxg"],
+    ["K", "podcast:item:guid"],
+    ["e", "80c48d992a38f9c445b943a9c9f1010b396676013443765750431a9004bdac05", "wss://example.relay", "252f10c83610ebca1a059c0bae8255eba2f95be4d1d7bcfa89d7248a82d9f111"],
+    ["k", "1111"],
+    ["p", "252f10c83610ebca1a059c0bae8255eba2f95be4d1d7bcfa89d7248a82d9f111"]
+  ],
+  "content": "I'm replying to the above comment.",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-22/kind-1111/samples/valid-reply-to-comment.json
+++ b/nips/nip-22/kind-1111/samples/valid-reply-to-comment.json
@@ -1,0 +1,16 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1111,
+  "tags": [
+    ["E", "768ac8720cdeb59227cf95e98b66560ef03d8bc9a90d721779e76e68fb42f5e6", "wss://example.relay", "fd913cd6fa9edb8405750cd02a8bbe16e158b8676c0e69fdc27436cc4a54cc9a"],
+    ["K", "1063"],
+    ["P", "fd913cd6fa9edb8405750cd02a8bbe16e158b8676c0e69fdc27436cc4a54cc9a"],
+    ["e", "5c83da77af1dec6d7289834998ad7aafbd9e2191396d75ec3cc27f5a77226f36", "wss://example.relay", "93ef2ebaaf9554661f33e79949007900bbc535d239a4c801c33a4d67d3e7f546"],
+    ["k", "1111"],
+    ["p", "93ef2ebaaf9554661f33e79949007900bbc535d239a4c801c33a4d67d3e7f546"]
+  ],
+  "content": "This is a reply to the above comment",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-22/kind-1111/samples/valid-website-comment.json
+++ b/nips/nip-22/kind-1111/samples/valid-website-comment.json
@@ -1,0 +1,14 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1111,
+  "tags": [
+    ["I", "https://abc.com/articles/1"],
+    ["K", "web"],
+    ["i", "https://abc.com/articles/1"],
+    ["k", "web"]
+  ],
+  "content": "Nice article!",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-23/kind-30023/samples/valid.rich-article.json
+++ b/nips/nip-23/kind-30023/samples/valid.rich-article.json
@@ -1,0 +1,19 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 30023,
+  "tags": [
+    ["d", "introduction-to-nostr"],
+    ["title", "Introduction to Nostr: A Decentralized Social Protocol"],
+    ["summary", "An overview of the Nostr protocol, its architecture, and why it matters for censorship-resistant communication."],
+    ["image", "https://example.com/images/nostr-banner.png"],
+    ["published_at", "1669900000"],
+    ["t", "nostr"],
+    ["t", "protocol"],
+    ["t", "decentralization"],
+    ["a", "30023:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:getting-started", "wss://relay.example.com"]
+  ],
+  "content": "# Introduction to Nostr\n\nNostr (Notes and Other Stuff Transmitted by Relays) is a simple, open protocol that enables a truly censorship-resistant global social network.\n\n## How It Works\n\nThe protocol is based on **cryptographic keypairs**. Every user has a keypair, and every event is signed. Clients send events to relays, and relays store and forward them.\n\n### Key Concepts\n\n- **Events**: The basic data structure, signed by the author\n- **Relays**: Servers that accept and store events\n- **Clients**: Applications that users interact with\n\n## Why It Matters\n\nUnlike centralized platforms, no single entity controls the network. Your identity is your keypair, and you can take it anywhere.\n\n> \"The network is the protocol, not the platform.\"\n\nFor more details, see the [NIP repository](https://github.com/nostr-protocol/nips).",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-25/kind-17/samples/valid-podcast-reaction.json
+++ b/nips/nip-25/kind-17/samples/valid-podcast-reaction.json
@@ -1,0 +1,14 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 17,
+  "tags": [
+    ["k", "podcast:guid"],
+    ["i", "podcast:guid:917393e3-1b1e-5cef-ace4-edaa54e1f810", "https://example.com/podcast/feed.xml"],
+    ["k", "podcast:item:guid"],
+    ["i", "podcast:item:guid:PC20-229", "https://example.com/podcast/episode/229"]
+  ],
+  "content": "+",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-25/kind-17/samples/valid-website-reaction.json
+++ b/nips/nip-25/kind-17/samples/valid-website-reaction.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 17,
+  "tags": [
+    ["i", "https://example.com/article/nostr-explained"],
+    ["k", "web"]
+  ],
+  "content": "⭐",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-25/kind-7/samples/valid-custom-emoji.json
+++ b/nips/nip-25/kind-7/samples/valid-custom-emoji.json
@@ -1,0 +1,13 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 7,
+  "tags": [
+    ["e", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["p", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"],
+    ["emoji", "smiley", "https://cdn.example.com/emoji/smiley.png"]
+  ],
+  "content": ":smiley:",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-25/kind-7/samples/valid-downvote.json
+++ b/nips/nip-25/kind-7/samples/valid-downvote.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 7,
+  "tags": [
+    ["e", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["p", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"]
+  ],
+  "content": "-",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-25/kind-7/samples/valid-with-k-tag.json
+++ b/nips/nip-25/kind-7/samples/valid-with-k-tag.json
@@ -1,0 +1,13 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 7,
+  "tags": [
+    ["e", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["p", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"],
+    ["k", "1"]
+  ],
+  "content": "+",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-25/kind-7/samples/valid-with-relay-hint.json
+++ b/nips/nip-25/kind-7/samples/valid-with-relay-hint.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 7,
+  "tags": [
+    ["e", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "wss://relay.example.com"],
+    ["p", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", "wss://relay.example.com"]
+  ],
+  "content": "+",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-32/kind-1985/samples/valid.with-namespace.json
+++ b/nips/nip-32/kind-1985/samples/valid.with-namespace.json
@@ -1,0 +1,13 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1985,
+  "tags": [
+    ["L", "social.coracle.ontology"],
+    ["l", "permaculture", "social.coracle.ontology"],
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-34/kind-30617/samples/valid-rich-repo.json
+++ b/nips/nip-34/kind-30617/samples/valid-rich-repo.json
@@ -1,0 +1,19 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 30617,
+  "tags": [
+    ["d", "nostr-client"],
+    ["name", "Nostr Client"],
+    ["description", "A reference Nostr client implementation"],
+    ["web", "https://github.com/example/nostr-client", "https://nostr-client.example.com"],
+    ["clone", "https://github.com/example/nostr-client.git", "git@github.com:example/nostr-client.git"],
+    ["relays", "wss://relay.example.com", "wss://relay2.example.com"],
+    ["maintainers", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"],
+    ["t", "nostr"],
+    ["t", "client"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-38/kind-30315/samples/valid-music-status.json
+++ b/nips/nip-38/kind-30315/samples/valid-music-status.json
@@ -1,0 +1,13 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 30315,
+  "tags": [
+    ["d", "music"],
+    ["r", "spotify:search:Intergalactic%20-%20Beastie%20Boys"],
+    ["expiration", "1670000300"]
+  ],
+  "content": "Intergalactic - Beastie Boys",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-52/kind-31922/samples/valid-rich-multi-day-event.json
+++ b/nips/nip-52/kind-31922/samples/valid-rich-multi-day-event.json
@@ -1,0 +1,26 @@
+{
+  "content": "Join us for the annual Nostr Developer Summit! Three days of talks, workshops, and hackathons focused on protocol development, interoperability, and the future of decentralized social media. Meals and refreshments provided.",
+  "created_at": 1670000000,
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "kind": 31922,
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "tags": [
+    ["d", "nostr-dev-summit-2025"],
+    ["title", "Nostr Developer Summit 2025"],
+    ["start", "2025-06-15"],
+    ["end", "2025-06-18"],
+    ["summary", "Three-day developer conference covering protocol improvements, NIP workshops, and a closing hackathon."],
+    ["image", "https://example.com/events/nostr-summit-2025-banner.png"],
+    ["location", "Paralelni Polis, Prague"],
+    ["location", "Delnicka 43, Prague 7, Czech Republic"],
+    ["g", "u2fkbv"],
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["p", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"],
+    ["t", "nostr"],
+    ["t", "development"],
+    ["t", "hackathon"],
+    ["r", "wss://relay.example.com"],
+    ["r", "wss://relay2.example.com"]
+  ]
+}

--- a/nips/nip-52/kind-31923/samples/valid-rich-time-based-event.json
+++ b/nips/nip-52/kind-31923/samples/valid-rich-time-based-event.json
@@ -1,0 +1,29 @@
+{
+  "content": "A deep-dive workshop on NIP-17 direct messages. We will cover encryption, relay selection, gift wrapping (NIP-59), and practical implementation patterns. Bring your laptop!",
+  "created_at": 1670000000,
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "kind": 31923,
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "tags": [
+    ["d", "nip17-workshop-2025"],
+    ["title", "NIP-17 Direct Messages Workshop"],
+    ["D", "20254"],
+    ["start", "1750089600"],
+    ["end", "1750100400"],
+    ["start_tzid", "Europe/Prague"],
+    ["end_tzid", "Europe/Prague"],
+    ["summary", "Hands-on workshop covering encrypted direct message implementation with NIP-17 and NIP-59 gift wrapping."],
+    ["image", "https://example.com/events/nip17-workshop.png"],
+    ["location", "Paralelni Polis, Room B"],
+    ["location", "Delnicka 43, Prague 7, Czech Republic"],
+    ["g", "u2fkbv"],
+    ["p", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"],
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["t", "nostr"],
+    ["t", "encryption"],
+    ["t", "nip17"],
+    ["r", "wss://relay.example.com"],
+    ["a", "31924:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:nostr-summit-cal"]
+  ]
+}

--- a/nips/nip-52/kind-31924/samples/valid-rich-calendar-with-events.json
+++ b/nips/nip-52/kind-31924/samples/valid-rich-calendar-with-events.json
@@ -1,0 +1,19 @@
+{
+  "content": "The official calendar for the Nostr Developer Summit 2025 in Prague. Includes all talks, workshops, and social events across the three-day program.",
+  "created_at": 1670000000,
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "kind": 31924,
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "tags": [
+    ["d", "nostr-summit-cal"],
+    ["title", "Nostr Developer Summit 2025 Schedule"],
+    ["summary", "Full three-day program for the annual Nostr Developer Summit in Prague."],
+    ["image", "https://example.com/events/nostr-summit-cal-banner.png"],
+    ["a", "31922:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:nostr-dev-summit-2025", "wss://relay.example.com"],
+    ["a", "31923:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:nip17-workshop-2025", "wss://relay.example.com"],
+    ["a", "31923:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:keynote-day1-2025", "wss://relay.example.com"],
+    ["a", "31923:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:closing-hackathon-2025", "wss://relay.example.com"],
+    ["a", "31922:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:social-dinner-2025", "wss://relay.example.com"]
+  ]
+}

--- a/nips/nip-52/kind-31925/samples/valid-rich-rsvp-accepted.json
+++ b/nips/nip-52/kind-31925/samples/valid-rich-rsvp-accepted.json
@@ -1,0 +1,16 @@
+{
+  "content": "Looking forward to the NIP-17 workshop! Will bring my implementation for review.",
+  "created_at": 1670000000,
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "kind": 31925,
+  "pubkey": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "tags": [
+    ["d", "rsvp-nip17-workshop"],
+    ["a", "31923:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:nip17-workshop-2025"],
+    ["status", "accepted"],
+    ["fb", "busy"],
+    ["e", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", "wss://relay.example.com"],
+    ["p", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "wss://relay.example.com"]
+  ]
+}

--- a/nips/nip-52/kind-31925/samples/valid-rich-rsvp-tentative.json
+++ b/nips/nip-52/kind-31925/samples/valid-rich-rsvp-tentative.json
@@ -1,0 +1,15 @@
+{
+  "content": "Might be able to attend depending on travel schedule.",
+  "created_at": 1670000000,
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "kind": 31925,
+  "pubkey": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "tags": [
+    ["d", "rsvp-summit-2025"],
+    ["a", "31922:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:nostr-dev-summit-2025"],
+    ["status", "tentative"],
+    ["fb", "free"],
+    ["p", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "wss://relay.example.com"]
+  ]
+}

--- a/nips/nip-56/kind-1984/samples/valid-spam-report.json
+++ b/nips/nip-56/kind-1984/samples/valid-spam-report.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1984,
+  "tags": [
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "spam"],
+    ["e", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", "spam"]
+  ],
+  "content": "Posting unsolicited commercial ads across multiple relays",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-57/kind-9735/samples/valid-rich-zap-receipt.json
+++ b/nips/nip-57/kind-9735/samples/valid-rich-zap-receipt.json
@@ -1,0 +1,17 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 9735,
+  "tags": [
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["P", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"],
+    ["e", "1111111111111111111111111111111111111111111111111111111111111111"],
+    ["a", "30023:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:my-article", "wss://relay.example.com"],
+    ["bolt11", "lnbc10u1pwyqk3hpp5qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsdp5jku3q"],
+    ["description", "{\"id\":\"2222222222222222222222222222222222222222222222222222222222222222\",\"pubkey\":\"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\",\"created_at\":1670000000,\"kind\":9734,\"tags\":[[\"p\",\"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\"],[\"relays\",\"wss://relay.example.com\",\"wss://relay2.example.com\"],[\"e\",\"1111111111111111111111111111111111111111111111111111111111111111\"],[\"a\",\"30023:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:my-article\",\"wss://relay.example.com\"]],\"content\":\"\",\"sig\":\"33333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333\"}"],
+    ["preimage", "4444444444444444444444444444444444444444444444444444444444444444"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-58/kind-30008/samples/valid-rich-profile-badges.json
+++ b/nips/nip-58/kind-30008/samples/valid-rich-profile-badges.json
@@ -1,0 +1,17 @@
+{
+  "content": "",
+  "created_at": 1670000000,
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "kind": 30008,
+  "pubkey": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "tags": [
+    ["d", "profile_badges"],
+    ["a", "30009:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:nip-contributor"],
+    ["e", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", "wss://relay.example.com"],
+    ["a", "30009:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:nostr-og"],
+    ["e", "1111111111111111111111111111111111111111111111111111111111111111", "wss://relay.example.com"],
+    ["a", "30009:2222222222222222222222222222222222222222222222222222222222222222:relay-operator"],
+    ["e", "3333333333333333333333333333333333333333333333333333333333333333", "wss://relay.example.com"]
+  ]
+}

--- a/nips/nip-58/kind-30009/samples/valid-rich-badge-definition.json
+++ b/nips/nip-58/kind-30009/samples/valid-rich-badge-definition.json
@@ -1,0 +1,16 @@
+{
+  "content": "",
+  "created_at": 1670000000,
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "kind": 30009,
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "tags": [
+    ["d", "nip-contributor"],
+    ["name", "NIP Contributor"],
+    ["description", "Awarded to developers who have authored or significantly contributed to a merged Nostr Implementation Possibility."],
+    ["image", "https://example.com/badges/nip-contributor.png", "1024x1024"],
+    ["thumb", "https://example.com/badges/nip-contributor-256.png", "256x256"],
+    ["thumb", "https://example.com/badges/nip-contributor-64.png", "64x64"]
+  ]
+}

--- a/nips/nip-58/kind-8/samples/valid-rich-badge-award.json
+++ b/nips/nip-58/kind-8/samples/valid-rich-badge-award.json
@@ -1,0 +1,14 @@
+{
+  "content": "",
+  "created_at": 1670000000,
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "kind": 8,
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "tags": [
+    ["a", "30009:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:nip-contributor"],
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "wss://relay.example.com"],
+    ["p", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", "wss://relay.example.com"],
+    ["p", "1111111111111111111111111111111111111111111111111111111111111111", "wss://relay.example.com"]
+  ]
+}

--- a/nips/nip-61/kind-9321/samples/valid-rich-nutzap.json
+++ b/nips/nip-61/kind-9321/samples/valid-rich-nutzap.json
@@ -1,0 +1,15 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 9321,
+  "tags": [
+    ["proof", "{\"amount\":21,\"C\":\"02277c66191736eb72fce9d975d08e3191f8f96afb73ab1eec37e4465683066d3f\",\"id\":\"000a93d6f8a1d2c4\",\"secret\":\"[\\\"P2PK\\\",{\\\"nonce\\\":\\\"b00bdd0467b0090a25bdf2d2f0d45ac4e355c482c1418350f273a04fedaaee83\\\",\\\"data\\\":\\\"02eaee8939e3565e48cc62967e2fde9d8e2a4b3ec0081f29eceff5c64ef10ac1ed\\\"}]\",\"dleq\":{\"e\":\"abcdef0123456789\",\"s\":\"fedcba9876543210\"}}"],
+    ["u", "https://mint.minibits.cash/Bitcoin"],
+    ["unit", "sat"],
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["e", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"]
+  ],
+  "content": "Great post, have some sats!",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-64/kind-64/samples/valid-full-game.json
+++ b/nips/nip-64/kind-64/samples/valid-full-game.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 64,
+  "tags": [
+    ["alt", "Fischer vs. Spassky in Belgrade on 1992-11-04 (Round 29)"]
+  ],
+  "content": "[Event \"F/S Return Match\"]\n[Site \"Belgrade, Serbia JUG\"]\n[Date \"1992.11.04\"]\n[Round \"29\"]\n[White \"Fischer, Robert J.\"]\n[Black \"Spassky, Boris V.\"]\n[Result \"1/2-1/2\"]\n\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Nb8 10. d4 Nbd7 11. c4 c6 12. cxb5 axb5 13. Nc3 Bb7 14. Bg5 b4 15. Nb1 h6 16. Bh4 c5 17. dxe5 Nxe4 18. Bxe7 Qxe7 19. exd6 Qf6 20. Nbd2 Nxd6 21. Nc4 Nxc4 22. Bxc4 Nb6 23. Ne5 Rae8 24. Bxf7+ Rxf7 25. Nxf7 Rxe1+ 26. Qxe1 Kxf7 27. Qe3 Qg5 28. Qxg5 hxg5 29. b3 Ke6 30. a3 Kd5 31. axb4 cxb4 32. Ra5+ Kd6 33. Rg5 1/2-1/2",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-65/kind-10002/samples/valid-mixed-relays.json
+++ b/nips/nip-65/kind-10002/samples/valid-mixed-relays.json
@@ -1,0 +1,16 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 10002,
+  "tags": [
+    ["r", "wss://relay.damus.io"],
+    ["r", "wss://nos.lol"],
+    ["r", "wss://relay.nostr.band", "read"],
+    ["r", "wss://search.nos.today", "read"],
+    ["r", "wss://relay.primal.net", "write"],
+    ["r", "wss://nostr.wine", "write"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-68/kind-20/samples/valid-rich-picture.json
+++ b/nips/nip-68/kind-20/samples/valid-rich-picture.json
@@ -1,0 +1,37 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 20,
+  "tags": [
+    ["title", "Sunset at Copacabana"],
+    [
+      "imeta",
+      "url https://cdn.example.com/photos/sunset-copacabana-4k.jpg",
+      "m image/jpeg",
+      "x cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "dim 3840x2160",
+      "blurhash LEHV6nWB2yk8pyo0adR*.7kCMdnj",
+      "alt A vibrant sunset over Copacabana beach with silhouettes of palm trees",
+      "fallback https://backup.example.com/photos/sunset-copacabana-4k.jpg"
+    ],
+    [
+      "imeta",
+      "url https://cdn.example.com/photos/sunset-copacabana-wide.jpg",
+      "m image/webp",
+      "x dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "dim 1920x1080",
+      "blurhash LKO2:N%2Tw=w]~RBVZRi};RPxuwH",
+      "alt Wide-angle shot of the sunset with the Sugarloaf Mountain in the distance"
+    ],
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["t", "sunset"],
+    ["t", "beach"],
+    ["t", "photography"],
+    ["location", "Copacabana Beach, Rio de Janeiro, Brazil"],
+    ["g", "75cm2g"],
+    ["content-warning", ""]
+  ],
+  "content": "Golden hour at Copacabana. The sun dipped below the horizon painting the sky in shades of amber and crimson. Shot on a Fujifilm X-T5 with a 16mm f/1.4 lens.",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-71/kind-34235/samples/valid-rich-video.json
+++ b/nips/nip-71/kind-34235/samples/valid-rich-video.json
@@ -1,0 +1,73 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 34235,
+  "tags": [
+    ["d", "bitcoin-explained-ep12"],
+    ["title", "Bitcoin Explained: Episode 12 - Lightning Network Deep Dive"],
+    [
+      "imeta",
+      "url https://cdn.example.com/videos/btc-ep12-1080p.mp4",
+      "m video/mp4",
+      "x cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "dim 1920x1080",
+      "duration 2847",
+      "bitrate 5000000",
+      "image https://cdn.example.com/thumbs/btc-ep12-poster.jpg",
+      "fallback https://backup.example.com/videos/btc-ep12-1080p.mp4",
+      "service nip96"
+    ],
+    [
+      "text-track",
+      "https://cdn.example.com/subs/btc-ep12-en.vtt",
+      "captions",
+      "en"
+    ],
+    [
+      "text-track",
+      "https://cdn.example.com/subs/btc-ep12-es.vtt",
+      "captions",
+      "es"
+    ],
+    [
+      "segment",
+      "0",
+      "120",
+      "Introduction",
+      "https://cdn.example.com/thumbs/btc-ep12-seg1.jpg"
+    ],
+    [
+      "segment",
+      "120",
+      "1200",
+      "How Lightning Channels Work",
+      "https://cdn.example.com/thumbs/btc-ep12-seg2.jpg"
+    ],
+    [
+      "segment",
+      "1200",
+      "2847",
+      "Routing and Pathfinding",
+      "https://cdn.example.com/thumbs/btc-ep12-seg3.jpg"
+    ],
+    ["published_at", "1669990000"],
+    ["alt", "A 47-minute video explaining the Bitcoin Lightning Network"],
+    ["t", "bitcoin"],
+    ["t", "lightning"],
+    ["t", "education"],
+    [
+      "p",
+      "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "wss://relay.example.com"
+    ],
+    ["r", "https://lightning.network/lightning-network-paper.pdf"],
+    [
+      "origin",
+      "youtube",
+      "dQw4w9WgXcQ"
+    ]
+  ],
+  "content": "Deep dive into the Lightning Network: how payment channels work, HTLC mechanics, onion routing for privacy, and the current state of LN adoption. Episode 12 in our Bitcoin Explained series.",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-72/kind-34550/samples/valid.rich-community.json
+++ b/nips/nip-72/kind-34550/samples/valid.rich-community.json
@@ -1,0 +1,21 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 34550,
+  "tags": [
+    ["d", "nostr-dev"],
+    ["name", "Nostr Development"],
+    ["description", "A community for nostr protocol developers. Discuss NIPs, share implementations, and collaborate on the future of decentralized social media."],
+    ["image", "https://example.com/nostr-dev-banner.png", "1024x512"],
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "wss://relay.example.com", "moderator"],
+    ["p", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", "wss://relay2.example.com", "moderator"],
+    ["p", "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", "", "moderator"],
+    ["relay", "wss://relay.example.com", "author"],
+    ["relay", "wss://relay2.example.com", "requests"],
+    ["relay", "wss://relay3.example.com", "approvals"],
+    ["relay", "wss://relay4.example.com"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-72/kind-4550/samples/valid.with-content.json
+++ b/nips/nip-72/kind-4550/samples/valid.with-content.json
@@ -1,0 +1,14 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 4550,
+  "tags": [
+    ["a", "34550:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:photography", "wss://relay.example.com"],
+    ["e", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", "wss://relay.example.com"],
+    ["p", "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", "wss://relay.example.com"],
+    ["k", "1"]
+  ],
+  "content": "{\"id\":\"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\",\"pubkey\":\"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\",\"created_at\":1669999000,\"kind\":1,\"tags\":[[\"a\",\"34550:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:photography\",\"wss://relay.example.com\"]],\"content\":\"Check out this amazing sunset photo I took yesterday!\",\"sig\":\"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\"}",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-75/kind-9041/samples/valid-with-optional-fields.json
+++ b/nips/nip-75/kind-9041/samples/valid-with-optional-fields.json
@@ -1,0 +1,38 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 9041,
+  "tags": [
+    ["amount", "21000000"],
+    [
+      "relays",
+      "wss://relay.damus.io",
+      "wss://relay.nostr.band",
+      "wss://nos.lol"
+    ],
+    ["closed_at", "1672531200"],
+    ["image", "https://cdn.example.com/goals/open-source-fund.jpg"],
+    ["summary", "Funding milestone for the open-source Nostr client development sprint"],
+    [
+      "a",
+      "30023:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:dev-roadmap-2025",
+      "wss://relay.example.com"
+    ],
+    ["r", "https://github.com/example/nostr-client"],
+    [
+      "zap",
+      "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "wss://relay.example.com",
+      "3"
+    ],
+    [
+      "zap",
+      "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "wss://relay.example.com",
+      "1"
+    ]
+  ],
+  "content": "Help us fund the next phase of our open-source Nostr client. We are building a cross-platform client with NIP-17 DMs, NIP-65 relay management, and NIP-57 zap support. Every sat counts!",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-84/kind-9802/samples/valid.with-attribution.json
+++ b/nips/nip-84/kind-9802/samples/valid.with-attribution.json
@@ -1,0 +1,15 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 9802,
+  "tags": [
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "wss://relay.example.com", "author"],
+    ["p", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", "wss://relay.example.com", "editor"],
+    ["e", "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", "wss://relay.example.com"],
+    ["a", "30023:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:bitcoin-scaling", "wss://relay.example.com"],
+    ["context", "The Lightning Network represents a significant leap forward in Bitcoin's scalability. By enabling off-chain transactions, it allows for near-instant payments with minimal fees, fundamentally changing how we think about micropayments."]
+  ],
+  "content": "near-instant payments with minimal fees, fundamentally changing how we think about micropayments",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-85/kind-10040/samples/invalid.wrong-kind.json
+++ b/nips/nip-85/kind-10040/samples/invalid.wrong-kind.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1,
+  "tags": [
+    ["30382:rank", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "wss://nip85.example.com"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-85/kind-10040/samples/valid.json
+++ b/nips/nip-85/kind-10040/samples/valid.json
@@ -1,0 +1,13 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 10040,
+  "tags": [
+    ["30382:rank", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "wss://nip85.example.com"],
+    ["30382:zap_amt_sent", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "wss://nip85.example.com"],
+    ["30382:followers", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", "wss://relay.example.com"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-85/kind-10040/samples/valid.minimal.json
+++ b/nips/nip-85/kind-10040/samples/valid.minimal.json
@@ -1,0 +1,11 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 10040,
+  "tags": [
+    ["30382:rank", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "wss://nip85.example.com"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-85/kind-10040/schema.yaml
+++ b/nips/nip-85/kind-10040/schema.yaml
@@ -1,0 +1,20 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind10040
+description: "NIP-85 Trusted Assertions provider declaration"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 10040
+        errorMessage: "kind must equal 10040"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        errorMessage:
+          minItems: "tags must contain at least one provider declaration tag"
+    required:
+      - kind
+      - tags

--- a/nips/nip-87/kind-38000/samples/invalid.wrong-kind.json
+++ b/nips/nip-87/kind-38000/samples/invalid.wrong-kind.json
@@ -1,0 +1,12 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1,
+  "tags": [
+    ["d", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["k", "38172"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-87/kind-38000/samples/valid.fedimint-recommendation.json
+++ b/nips/nip-87/kind-38000/samples/valid.fedimint-recommendation.json
@@ -1,0 +1,14 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 38000,
+  "tags": [
+    ["d", "federation-id-abc123"],
+    ["k", "38173"],
+    ["u", "fed11qgqzc2nhwden5te0vejkg6tdd9h8gepwvejhyamrvaak8e6q"],
+    ["a", "38173:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd:federation-id-abc123", "wss://relay.example.com"]
+  ],
+  "content": "I trust this federation with my life.",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-87/kind-38000/samples/valid.json
+++ b/nips/nip-87/kind-38000/samples/valid.json
@@ -1,0 +1,14 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 38000,
+  "tags": [
+    ["d", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["k", "38172"],
+    ["u", "https://cashu.example.com"],
+    ["a", "38172:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "wss://relay.example.com"]
+  ],
+  "content": "Reliable mint, fast redemptions and good uptime.",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-87/kind-38000/schema.yaml
+++ b/nips/nip-87/kind-38000/schema.yaml
@@ -1,0 +1,27 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: kind38000
+description: "NIP-87 Ecash Mint Recommendation event"
+allOf:
+  - $ref: "@/note.yaml"
+  - type: object
+    properties:
+      kind:
+        const: 38000
+        errorMessage: "kind must equal 38000"
+      tags:
+        type: array
+        items:
+          $ref: "@/tag.yaml"
+        minItems: 1
+        allOf:
+          - contains:
+              $ref: "@/tag/d.yaml"
+            errorMessage:
+              contains: "tags must include a d tag with the mint identifier"
+          - contains:
+              $ref: "@/tag/k.yaml"
+            errorMessage:
+              contains: "tags must include a k tag with the kind number being recommended"
+    required:
+      - kind
+      - tags

--- a/nips/nip-87/kind-38173/samples/valid.multi-invite.json
+++ b/nips/nip-87/kind-38173/samples/valid.multi-invite.json
@@ -1,0 +1,15 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 38173,
+  "tags": [
+    ["d", "federation-signet-xyz789"],
+    ["u", "fed11qgqzc2nhwden5te0vejkg6tdd9h8gepwvejhyamrvaak8e6q"],
+    ["u", "fed11qgqrgpsyxzserqwp4jsr5qce2wkfznfsajt4e2xsmu2"],
+    ["modules", "lightning,wallet,mint"],
+    ["n", "signet"]
+  ],
+  "content": "{\"name\":\"Signet Test Federation\",\"about\":\"A test federation running on signet for development purposes\"}",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-88/kind-1018/samples/valid-multi-response.json
+++ b/nips/nip-88/kind-1018/samples/valid-multi-response.json
@@ -1,0 +1,13 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1018,
+  "tags": [
+    ["response", "opt1"],
+    ["response", "opt3"],
+    ["e", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-88/kind-1068/samples/valid-polltype-endsat.json
+++ b/nips/nip-88/kind-1068/samples/valid-polltype-endsat.json
@@ -1,0 +1,16 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1068,
+  "tags": [
+    ["option", "opt1", "Yes"],
+    ["option", "opt2", "No"],
+    ["option", "opt3", "Maybe"],
+    ["relay", "wss://relay.example.com"],
+    ["polltype", "multiplechoice"],
+    ["endsAt", "1670100000"]
+  ],
+  "content": "Should we implement this feature?",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-88/kind-1068/samples/valid-singlechoice.json
+++ b/nips/nip-88/kind-1068/samples/valid-singlechoice.json
@@ -1,0 +1,16 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1068,
+  "tags": [
+    ["option", "opt1", "Red"],
+    ["option", "opt2", "Blue"],
+    ["option", "opt3", "Green"],
+    ["option", "opt4", "Yellow"],
+    ["relay", "wss://relay.example.com"],
+    ["polltype", "singlechoice"]
+  ],
+  "content": "What is your favorite color?",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-89/kind-31990/samples/valid-with-platforms.json
+++ b/nips/nip-89/kind-31990/samples/valid-with-platforms.json
@@ -1,0 +1,19 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 31990,
+  "tags": [
+    ["d", "my-nostr-client"],
+    ["k", "0"],
+    ["k", "1"],
+    ["k", "7"],
+    ["web", "https://app.example.com/<bech32>", "nevent"],
+    ["web", "https://app.example.com/p/<bech32>", "nprofile"],
+    ["web", "https://app.example.com/e/<bech32>"],
+    ["ios", "example://open/<bech32>"],
+    ["android", "intent://open/<bech32>"]
+  ],
+  "content": "{\"name\":\"Example Nostr Client\",\"about\":\"A full-featured nostr client for web, iOS, and Android\",\"picture\":\"https://example.com/icon.png\"}",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-90/kind-5300/samples/valid.content-discovery.json
+++ b/nips/nip-90/kind-5300/samples/valid.content-discovery.json
@@ -1,0 +1,15 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 5300,
+  "tags": [
+    ["i", "philosophy", "text"],
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["output", "text/plain"],
+    ["relays", "wss://relay.example.com", "wss://relay2.example.com"],
+    ["bid", "5000"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-90/kind-5301/samples/valid.people-discovery.json
+++ b/nips/nip-90/kind-5301/samples/valid.people-discovery.json
@@ -1,0 +1,15 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 5301,
+  "tags": [
+    ["i", "cool people", "text"],
+    ["p", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+    ["output", "text/plain"],
+    ["relays", "wss://relay.example.com"],
+    ["bid", "3000"]
+  ],
+  "content": "",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-94/kind-1063/samples/valid.rich-metadata.json
+++ b/nips/nip-94/kind-1063/samples/valid.rich-metadata.json
@@ -1,0 +1,21 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 1063,
+  "tags": [
+    ["url", "https://example.com/files/sunset-beach.jpg"],
+    ["m", "image/jpeg"],
+    ["x", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"],
+    ["ox", "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"],
+    ["size", "1048576"],
+    ["dim", "1920x1080"],
+    ["blurhash", "LEHV6nWB2yk8pyoJadR*.7kCMdnj"],
+    ["thumb", "https://example.com/files/sunset-beach-thumb.jpg"],
+    ["image", "https://example.com/files/sunset-beach-preview.jpg"],
+    ["summary", "A vibrant sunset over a tropical beach with palm trees silhouetted against the sky"],
+    ["alt", "Photograph of a sunset over a beach with palm trees"]
+  ],
+  "content": "Sunset at the beach",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}

--- a/nips/nip-99/kind-30402/samples/valid.rich-listing.json
+++ b/nips/nip-99/kind-30402/samples/valid.rich-listing.json
@@ -1,0 +1,24 @@
+{
+  "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "created_at": 1670000000,
+  "kind": 30402,
+  "tags": [
+    ["d", "vintage-synth-2024"],
+    ["title", "Roland Juno-106 Analog Synthesizer"],
+    ["summary", "Fully serviced vintage analog polysynth with new voice chips. Excellent condition."],
+    ["published_at", "1669900000"],
+    ["location", "Portland, OR"],
+    ["price", "1500", "USD"],
+    ["status", "active"],
+    ["t", "synthesizer"],
+    ["t", "music"],
+    ["t", "vintage"],
+    ["t", "analog"],
+    ["image", "https://example.com/images/juno106-front.jpg"],
+    ["image", "https://example.com/images/juno106-back.jpg"],
+    ["g", "u21"]
+  ],
+  "content": "# Roland Juno-106 Analog Synthesizer\n\nSelling my beloved Juno-106. This synth has been fully serviced with all six voice chips replaced with Analogue Renaissance clones. No more failing voices!\n\n## Condition\n- Cosmetically 8/10 (minor wear on sliders)\n- Functionally 10/10 (all voices, chorus, everything works)\n- Original power cable included\n\n## Why I'm selling\nDownsizing my studio. Prefer local pickup but can ship at buyer's expense.\n\nDM me for more photos or questions.",
+  "sig": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+}


### PR DESCRIPTION
## Summary
- Add 66 new sample JSON files and 2 new schemas across 25 NIPs
- New schemas: NIP-85 kind 10040 (Trusted Assertions), NIP-87 kind 38000 (Ecash Mint Recommendation)
- All 2179 tests pass (557 sample validations, 0 failures)

### Commits
1. **feat**: NIP-85 kind 10040 + NIP-87 kind 38000 schemas and samples
2. **P0 comments/polls**: NIP-22 kind 1111 (6 comment patterns), NIP-88 kind 1018/1068
3. **P0 reactions/deletion/community/DVM**: NIP-09, NIP-25, NIP-72, NIP-90
4. **P1 social**: NIP-02, NIP-17, NIP-23, NIP-25/17, NIP-32, NIP-56
5. **P1 content/monetization**: NIP-57, NIP-61, NIP-64, NIP-68, NIP-71, NIP-72/4550, NIP-75, NIP-84, NIP-87/38173, NIP-94, NIP-99
6. **P2**: NIP-01, NIP-18, NIP-34, NIP-38, NIP-52, NIP-58, NIP-65, NIP-89

### Not included
- NIP-66 kind 10166/30166 samples (goes to PR #106)

## Test plan
- [x] `pnpm build` succeeds
- [x] `pnpm test` — 2179 tests pass, 557 sample validations pass
- [x] All valid samples pass AJV schema validation
- [x] All invalid samples fail AJV schema validation
- [x] Hex string lengths verified (64-char id/pubkey, 128-char sig)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a large collection of new sample event JSON fixtures covering many NIPs/kinds (examples: profiles, replies, replies/threads, media, polls, badges, relays, RSVP/events, listings, articles, zaps, calendars, and multi-recipient/recipient patterns).
  * Added new JSON Schema definitions for specific NIP validation (trusted assertions and ecash mint recommendations) to illustrate expected schema constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->